### PR TITLE
refactor: add data services and use them

### DIFF
--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -1,0 +1,22 @@
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../amplify/data/resource';
+
+const client = generateClient<Schema>();
+
+export function listCampaigns(
+  options?: Parameters<typeof client.models.Campaign.list>[0]
+) {
+  return client.models.Campaign.list(options);
+}
+
+export function createCampaign(
+  input: Parameters<typeof client.models.Campaign.create>[0]
+) {
+  return client.models.Campaign.create(input);
+}
+
+export function updateCampaign(
+  input: Parameters<typeof client.models.Campaign.update>[0]
+) {
+  return client.models.Campaign.update(input);
+}

--- a/src/services/progressService.ts
+++ b/src/services/progressService.ts
@@ -1,0 +1,61 @@
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../amplify/data/resource';
+
+const client = generateClient<Schema>();
+
+// CampaignProgress
+export function listCampaignProgress(
+  options?: Parameters<typeof client.models.CampaignProgress.list>[0]
+) {
+  return client.models.CampaignProgress.list(options);
+}
+
+export function createCampaignProgress(
+  input: Parameters<typeof client.models.CampaignProgress.create>[0]
+) {
+  return client.models.CampaignProgress.create(input);
+}
+
+export function updateCampaignProgress(
+  input: Parameters<typeof client.models.CampaignProgress.update>[0]
+) {
+  return client.models.CampaignProgress.update(input);
+}
+
+// SectionProgress
+export function listSectionProgress(
+  options?: Parameters<typeof client.models.SectionProgress.list>[0]
+) {
+  return client.models.SectionProgress.list(options);
+}
+
+export function createSectionProgress(
+  input: Parameters<typeof client.models.SectionProgress.create>[0]
+) {
+  return client.models.SectionProgress.create(input);
+}
+
+export function updateSectionProgress(
+  input: Parameters<typeof client.models.SectionProgress.update>[0]
+) {
+  return client.models.SectionProgress.update(input);
+}
+
+// UserProgress
+export function listUserProgress(
+  options?: Parameters<typeof client.models.UserProgress.list>[0]
+) {
+  return client.models.UserProgress.list(options);
+}
+
+export function createUserProgress(
+  input: Parameters<typeof client.models.UserProgress.create>[0]
+) {
+  return client.models.UserProgress.create(input);
+}
+
+export function updateUserProgress(
+  input: Parameters<typeof client.models.UserProgress.update>[0]
+) {
+  return client.models.UserProgress.update(input);
+}

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -1,0 +1,22 @@
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../amplify/data/resource';
+
+const client = generateClient<Schema>();
+
+export function listQuestions(
+  options?: Parameters<typeof client.models.Question.list>[0]
+) {
+  return client.models.Question.list(options);
+}
+
+export function createQuestion(
+  input: Parameters<typeof client.models.Question.create>[0]
+) {
+  return client.models.Question.create(input);
+}
+
+export function updateQuestion(
+  input: Parameters<typeof client.models.Question.update>[0]
+) {
+  return client.models.Question.update(input);
+}

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -1,0 +1,22 @@
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../amplify/data/resource';
+
+const client = generateClient<Schema>();
+
+export function listSections(
+  options?: Parameters<typeof client.models.Section.list>[0]
+) {
+  return client.models.Section.list(options);
+}
+
+export function createSection(
+  input: Parameters<typeof client.models.Section.create>[0]
+) {
+  return client.models.Section.create(input);
+}
+
+export function updateSection(
+  input: Parameters<typeof client.models.Section.update>[0]
+) {
+  return client.models.Section.update(input);
+}

--- a/src/services/userProfileService.ts
+++ b/src/services/userProfileService.ts
@@ -1,0 +1,22 @@
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../amplify/data/resource';
+
+const client = generateClient<Schema>();
+
+export function listUserProfiles(
+  options?: Parameters<typeof client.models.UserProfile.list>[0]
+) {
+  return client.models.UserProfile.list(options);
+}
+
+export function createUserProfile(
+  input: Parameters<typeof client.models.UserProfile.create>[0]
+) {
+  return client.models.UserProfile.create(input);
+}
+
+export function updateUserProfile(
+  input: Parameters<typeof client.models.UserProfile.update>[0]
+) {
+  return client.models.UserProfile.update(input);
+}


### PR DESCRIPTION
## Summary
- add service layer wrapping Amplify client for campaigns, progress, sections, questions, and profiles
- refactor `useCampaigns`, `useUserProfile`, and `useCampaignQuizData` hooks to consume services

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / unused vars in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689413bf4138832e9df54ffa10719dc0