### PR TITLE
refactor: centralize XP constants

### DIFF
--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { Card, Button, Heading, Text } from '@aws-amplify/ui-react';
 import { useProgress } from '../context/ProgressContext';
+import {
+  XP_PER_LEVEL,
+  getXPWithinLevel,
+  calculateXPProgress,
+} from '../utils/xp';
 
 type AnnouncementBannerProps = {
   /** Optional callback when a level up occurs. Useful for analytics. */
@@ -8,8 +13,6 @@ type AnnouncementBannerProps = {
   /** Optional callback when the banner is dismissed. */
   onDismiss?: () => void;
 };
-
-const XP_PER_LEVEL = 100;
 
 export default function AnnouncementBanner({ onLevelUp, onDismiss }: AnnouncementBannerProps) {
   const { xp, level, completedSections } = useProgress();
@@ -39,8 +42,8 @@ export default function AnnouncementBanner({ onLevelUp, onDismiss }: Announcemen
       newDesc = `${count} completed section${count === 1 ? '' : 's'}!`;
       newIndicator = '✓';
     } else if (xp > prevXP.current) {
-      const currentXP = xp % XP_PER_LEVEL;
-      const pct = Math.max(0, Math.min(100, Math.round((currentXP / XP_PER_LEVEL) * 100)));
+      const currentXP = getXPWithinLevel(xp, XP_PER_LEVEL);
+      const pct = Math.round(calculateXPProgress(currentXP, XP_PER_LEVEL));
       newTitle = 'Leveling up!';
       newDesc = `You’ve earned ${currentXP} XP toward ${XP_PER_LEVEL}. Keep going to unlock the next section.`;
       newIndicator = `${pct}%`;

--- a/src/components/UserStatsPanel.tsx
+++ b/src/components/UserStatsPanel.tsx
@@ -1,6 +1,12 @@
 // src/components/UserStatsPanel.tsx
 import { Flex, Heading, Text, View, useTheme, Divider, Badge } from '@aws-amplify/ui-react';
 import { useProgress } from '../context/ProgressContext';
+import {
+  XP_PER_LEVEL,
+  getXPWithinLevel,
+  calculateXPProgress,
+  getXPToNextLevel,
+} from '../utils/xp';
 
 interface UserAttributes {
   name?: string;
@@ -100,7 +106,6 @@ export default function UserStatsPanel({ user, headerHeight, spacing }: UserStat
 
   // Defensive defaults
   const safeXP = Number.isFinite(xp) ? Math.max(0, xp) : 0;
-  const safeMax = 100;
 
   // Prefer saved display name; fall back to username/email
   const shownName =
@@ -110,9 +115,9 @@ export default function UserStatsPanel({ user, headerHeight, spacing }: UserStat
     'N/A';
 
   // Per-level math
-  const progressWithinLevel = safeXP % safeMax;
-  const levelPercent = (progressWithinLevel / safeMax) * 100; // fractional for smooth animation
-  const nextLevelIn = Math.max(0, safeMax - progressWithinLevel);
+  const progressWithinLevel = getXPWithinLevel(safeXP, XP_PER_LEVEL);
+  const levelPercent = calculateXPProgress(progressWithinLevel, XP_PER_LEVEL);
+  const nextLevelIn = getXPToNextLevel(safeXP, XP_PER_LEVEL);
 
   const rank = getRankForLevel(level);
 
@@ -139,7 +144,7 @@ export default function UserStatsPanel({ user, headerHeight, spacing }: UserStat
       <Flex direction="row" alignItems="center" gap="small" marginBottom="small">
         <Badge variation="info">Level {level}</Badge>
         <Text color={tokens.colors.font.secondary} fontSize="0.9rem">
-          {progressWithinLevel}/{safeMax} XP this level
+          {progressWithinLevel}/{XP_PER_LEVEL} XP this level
         </Text>
       </Flex>
 

--- a/src/context/ProgressContext.tsx
+++ b/src/context/ProgressContext.tsx
@@ -1,5 +1,6 @@
 /* eslint react-refresh/only-export-components: off */
 import { createContext, useContext, useEffect, useMemo, useState, ReactNode } from 'react';
+import { XP_PER_LEVEL, getLevelFromXP } from '../utils/xp';
 
 interface ProgressContextValue {
   xp: number;
@@ -22,8 +23,6 @@ interface ProviderProps {
   children: ReactNode;
 }
 
-const XP_PER_LEVEL = 100;
-
 export function ProgressProvider({
   initialXP = 0,
   initialStreak = 0,
@@ -42,7 +41,7 @@ export function ProgressProvider({
   useEffect(() => setCompletedSections(initialCompletedSections), [initialCompletedSections]);
   useEffect(() => setCompletedCampaigns(initialCompletedCampaigns), [initialCompletedCampaigns]);
 
-  const level = useMemo(() => Math.floor(xp / XP_PER_LEVEL) + 1, [xp]);
+  const level = useMemo(() => getLevelFromXP(xp, XP_PER_LEVEL), [xp]);
 
   const awardXP = (amount: number) => setXP((prev) => prev + amount);
   const markSectionComplete = (section: number) =>

--- a/src/utils/xp.ts
+++ b/src/utils/xp.ts
@@ -1,4 +1,31 @@
-export function calculateXPProgress(currentXP: number, maxXP: number = 100): number {
-  return Math.min(100, (currentXP / maxXP) * 100);
+export const XP_PER_LEVEL = 100;
+
+export function calculateXPProgress(
+  currentXP: number,
+  maxXP: number = XP_PER_LEVEL,
+): number {
+  const pct = (currentXP / maxXP) * 100;
+  return Math.max(0, Math.min(100, pct));
+}
+
+export function getLevelFromXP(
+  xp: number,
+  xpPerLevel: number = XP_PER_LEVEL,
+): number {
+  return Math.floor(xp / xpPerLevel) + 1;
+}
+
+export function getXPWithinLevel(
+  xp: number,
+  xpPerLevel: number = XP_PER_LEVEL,
+): number {
+  return xp % xpPerLevel;
+}
+
+export function getXPToNextLevel(
+  xp: number,
+  xpPerLevel: number = XP_PER_LEVEL,
+): number {
+  return Math.max(0, xpPerLevel - getXPWithinLevel(xp, xpPerLevel));
 }
 


### PR DESCRIPTION
## Summary
- centralize XP_PER_LEVEL and XP helpers in utils/xp
- use shared XP utilities in ProgressContext, AnnouncementBanner, and UserStatsPanel

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Cannot find modules, TS errors)


------
https://chatgpt.com/codex/tasks/task_e_6894314590cc832eafc80ca231f7554f