### PR TITLE
Refactor campaign gallery to load its own data

### DIFF
--- a/src/components/CampaignGallery.tsx
+++ b/src/components/CampaignGallery.tsx
@@ -1,25 +1,15 @@
 // src/components/CampaignGallery.tsx
 import { memo, type CSSProperties } from 'react';
+import { useAuthenticator } from '@aws-amplify/ui-react';
 import { useActiveCampaign } from '../context/ActiveCampaignContext';
+import { useCampaigns, type UICampaign } from '../hooks/useCampaigns';
 import { useCampaignThumbnail } from '../hooks/useCampaignThumbnail';
 
 
-export type CampaignCard = {
-  id: string;
-  title: string;
-  description?: string | null;
-  order?: number | null;
-  isActive?: boolean | null;
-  locked?: boolean; // from useCampaigns hook
-  // Thumbnails
+// Optional thumbnail props for campaigns
+type CampaignCard = UICampaign & {
   thumbnailKey?: string | null;
-  thumbnailUrl?: string | null;
   thumbnailAlt?: string | null;
-};
-
-type Props = {
-  campaigns: CampaignCard[];
-  loading?: boolean;
 };
 
 const containerStyle: CSSProperties = {
@@ -124,7 +114,10 @@ function CampaignCardView({
   );
 }
 
-function CampaignGalleryInner({ campaigns, loading }: Props) {
+function CampaignGalleryInner() {
+  const { user } = useAuthenticator((ctx) => [ctx.user]);
+  const userId = user?.userId;
+  const { campaigns, loading } = useCampaigns(userId);
   const { activeCampaignId, setActiveCampaignId } = useActiveCampaign();
   if (loading) return <div>Loading campaigns…</div>;
   if (!campaigns?.length) return <div>No campaigns yet.</div>;

--- a/src/pages/AuthenticatedShell.tsx
+++ b/src/pages/AuthenticatedShell.tsx
@@ -10,7 +10,6 @@ import CampaignCanvas from '../components/CampaignCanvas';
 import UserStatsPanel from '../components/UserStatsPanel';
 
 import { useUserProfile } from '../hooks/useUserProfile';
-import { useCampaigns } from '../hooks/useCampaigns';
 import { useHeaderHeight } from '../hooks/useHeaderHeight';
 import { ProgressProvider } from '../context/ProgressContext';
 import { ActiveCampaignProvider } from '../context/ActiveCampaignContext';
@@ -36,7 +35,6 @@ export default function AuthenticatedShell() {
 
   const emailFromAttrs = attrs?.email ?? null;
   const { profile } = useUserProfile(userId, emailFromAttrs);
-  const { campaigns, loading: campaignsLoading } = useCampaigns(userId);
 
   const headerRef = useRef<HTMLDivElement>(null);
   const headerHeight = useHeaderHeight(headerRef);
@@ -67,7 +65,7 @@ export default function AuthenticatedShell() {
           </div>
 
           <div style={{ gridArea: 'gallery' }}>
-            <CampaignGallery campaigns={campaigns} loading={campaignsLoading} />
+            <CampaignGallery />
           </div>
 
           <div style={{ gridArea: 'canvas' }}>


### PR DESCRIPTION
## Summary
- remove props from CampaignGallery and load campaigns using `useCampaigns`
- simplify AuthenticatedShell to render CampaignGallery without campaign props

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689438221a24832e9b76cb7b8a548a1c