### PR TITLE
feat: centralize answered question tracking

### DIFF
--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -11,12 +11,16 @@ export default function CampaignCanvas({ userId }: CampaignCanvasProps) {
   const { activeCampaignId: campaignId } = useActiveCampaign();
   const {
     questions,
-    progress,
     handleAnswer,
     sectionTextByNumber,
   } = useCampaignQuizData(userId, campaignId);
-
-  const { awardXP, markSectionComplete, markCampaignComplete } = useProgress();
+  const {
+    awardXP,
+    markSectionComplete,
+    markCampaignComplete,
+    answeredQuestions,
+    completedSections,
+  } = useProgress();
 
   const [index, setIndex] = useState(0);
 
@@ -36,13 +40,13 @@ export default function CampaignCanvas({ userId }: CampaignCanvasProps) {
     const ans = current.answers.find((a) => a.id === answerId);
     const isCorrect = !!ans?.isCorrect;
 
-    await handleAnswer({ questionId: current.id, isCorrect, xp: current.xpValue });
+    await handleAnswer({ questionId: current.id, isCorrect });
 
     if (isCorrect) {
-      const alreadyAnswered = progress?.answeredQuestions.includes(current.id);
+      const alreadyAnswered = answeredQuestions.includes(current.id);
       if (!alreadyAnswered) awardXP(current.xpValue ?? 0);
 
-      const answered = new Set(progress?.answeredQuestions ?? []);
+      const answered = new Set(answeredQuestions);
       answered.add(current.id);
 
       const sectionQs = questions.filter((q) => q.section === current.section);
@@ -51,7 +55,7 @@ export default function CampaignCanvas({ userId }: CampaignCanvasProps) {
       if (allAnswered && current.section != null) {
         markSectionComplete(current.section);
 
-        const completed = new Set(progress?.completedSections ?? []);
+        const completed = new Set(completedSections);
         completed.add(current.section);
         const allSections = new Set(questions.map((q) => q.section));
         if ([...allSections].every((n) => completed.has(n))) {


### PR DESCRIPTION
## Summary
- store answered question IDs in ProgressContext and expose helper to mark answers
- sync quiz data hook with ProgressContext rather than local arrays
- read answered question & section completion info from context in CampaignCanvas

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: ActiveCampaignContext.tsx(2,47): error TS1484: 'ReactNode' is a type and must be imported using a type-only import)


------
https://chatgpt.com/codex/tasks/task_e_68943a855e2c832e82d86db3285b97e9