### PR TITLE
Track daily streak during XP awards

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -86,6 +86,7 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(
     },
     ref
   ) => {
+    // Daily streak now comes directly from ProgressContext (updated via awardXP)
     const { xp, level, streak, completedSections } = useProgress();
     const maxXP = level * 100;
     const xpSub = `${xp}/${maxXP} XP`;


### PR DESCRIPTION
## Summary
- update ProgressContext awardXP to compute & persist daily streak and last blaze
- simplify question answer tracking to avoid double streak updates
- ensure Header pulls streak from ProgressContext

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68943ef8a35c832e8dbf4b6f62ba188a