### PR TITLE
feat: introduce public shell and login trigger

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,30 @@
 // src/App.tsx
-import { Authenticator } from '@aws-amplify/ui-react';
+import { useState } from 'react';
+import { Authenticator, useAuthenticator } from '@aws-amplify/ui-react';
+
 import AuthenticatedShell from './pages/AuthenticatedShell';
+import PublicShell from './pages/PublicShell';
 
 export default function App() {
+  return (
+    <Authenticator.Provider>
+      <AppContent />
+    </Authenticator.Provider>
+  );
+}
+
+function AppContent() {
+  const { authStatus } = useAuthenticator((ctx) => [ctx.authStatus]);
+  const [loginTriggered, setLoginTriggered] = useState(false);
+
+  if (authStatus === 'authenticated') {
+    return <AuthenticatedShell />;
+  }
+
+  if (!loginTriggered) {
+    return <PublicShell onRequireAuth={() => setLoginTriggered(true)} />;
+  }
+
   return (
     <Authenticator>
       <AuthenticatedShell />

--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -6,9 +6,10 @@ import { useUserProfile } from '../context/UserProfileContext';
 
 interface CampaignCanvasProps {
   userId: string;
+  onRequireAuth?: () => void;
 }
 
-export default function CampaignCanvas({ userId }: CampaignCanvasProps) {
+export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvasProps) {
   const { activeCampaignId: campaignId } = useActiveCampaign();
 
   const {
@@ -47,6 +48,10 @@ export default function CampaignCanvas({ userId }: CampaignCanvasProps) {
   const sectionText = current.section ? sectionTextByNumber.get(current.section) : undefined;
 
   const onAnswer = async (answerId: string) => {
+    if (!userId) {
+      onRequireAuth?.();
+      return;
+    }
     const ans = current.answers.find((a) => a.id === answerId);
     const isCorrect = !!ans?.isCorrect;
 

--- a/src/pages/PublicShell.tsx
+++ b/src/pages/PublicShell.tsx
@@ -1,0 +1,47 @@
+// src/pages/PublicShell.tsx
+import { useMemo } from 'react';
+
+import { ActiveCampaignProvider } from '../context/ActiveCampaignContext';
+import { Header as HeaderBar } from '../components/Header';
+import AnnouncementBanner from '../components/AnnouncementBanner';
+import CampaignGallery from '../components/CampaignGallery';
+import CampaignCanvas from '../components/CampaignCanvas';
+
+interface PublicShellProps {
+  onRequireAuth: () => void;
+}
+
+export default function PublicShell({ onRequireAuth }: PublicShellProps) {
+  const spacing = 24;
+  const gridStyle = useMemo(
+    () => ({
+      display: 'grid',
+      gridTemplateAreas: `"header header" "banner banner" "gallery canvas"`,
+      gridTemplateColumns: '1fr 2fr',
+      gridAutoRows: 'auto',
+      minHeight: '100vh',
+      gap: spacing,
+    }),
+    [spacing]
+  );
+
+  return (
+    <ActiveCampaignProvider>
+      <div style={gridStyle}>
+        <div style={{ gridArea: 'header' }}>
+          <HeaderBar />
+        </div>
+        <div style={{ gridArea: 'banner' }}>
+          <AnnouncementBanner />
+        </div>
+        <div style={{ gridArea: 'gallery' }}>
+          <CampaignGallery />
+        </div>
+        <div style={{ gridArea: 'canvas' }}>
+          <CampaignCanvas userId="" onRequireAuth={onRequireAuth} />
+        </div>
+      </div>
+    </ActiveCampaignProvider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add PublicShell for unauthenticated users with campaign browsing
- add auth trigger flow to App and CampaignCanvas

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module '../amplify_outputs.json'; type errors in AuthenticatedShell)*

------
https://chatgpt.com/codex/tasks/task_e_68943fd51418832ebcbaf7c8b2f73fcd