### PR TITLE
Refresh campaign gallery on completion and consolidate progress logic

### DIFF
--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -17,6 +17,7 @@ export default function CampaignCanvas({ userId }: CampaignCanvasProps) {
     sectionTextByNumber,
     loading,
     error,
+    sectionIdByNumber,
   } = useCampaignQuizData(userId, campaignId);
 
   const {
@@ -65,7 +66,8 @@ export default function CampaignCanvas({ userId }: CampaignCanvasProps) {
       const allAnswered = sectionQs.every((q) => answered.has(q.id));
 
       if (allAnswered && current.section != null) {
-        markSectionComplete(current.section);
+        const secId = sectionIdByNumber.get(current.section);
+        markSectionComplete(current.section, secId);
 
         const completed = new Set(completedSections);
         completed.add(current.section);

--- a/src/context/ProgressContext.tsx
+++ b/src/context/ProgressContext.tsx
@@ -16,6 +16,9 @@ import {
   listCampaignProgress,
   createCampaignProgress,
   updateCampaignProgress,
+  listSectionProgress,
+  createSectionProgress,
+  updateSectionProgress,
 } from '../services/progressService';
 import type { Schema } from '../../amplify/data/resource';
 import { getLevelFromXP } from '../utils/xp';
@@ -37,8 +40,8 @@ interface ProgressContextValue {
   completedCampaigns: string[];
   answeredQuestions: string[];
   awardXP: (amount: number) => void;
-  markSectionComplete: (section: number) => void;
-  markCampaignComplete: (campaignId: string) => void;
+  markSectionComplete: (section: number, sectionId?: string) => Promise<void>;
+  markCampaignComplete: (campaignId: string) => Promise<void>;
   markQuestionAnswered: (questionId: string) => void;
   subscribe: (listener: ProgressListener) => () => void;
 }
@@ -147,7 +150,7 @@ export function ProgressProvider({ userId, children }: ProviderProps) {
   );
 
   const markSectionComplete = useCallback(
-    (section: number) => {
+    async (section: number, sectionId?: string) => {
       setCompletedSections((prev) => {
         if (prev.includes(section)) return prev;
         const updated = [...prev, section];
@@ -159,8 +162,35 @@ export function ProgressProvider({ userId, children }: ProviderProps) {
         }
         return updated;
       });
+
+      if (sectionId) {
+        try {
+          const res = await listSectionProgress({
+            filter: {
+              and: [
+                { userId: { eq: userId } },
+                { sectionId: { eq: sectionId } },
+              ],
+            },
+            selectionSet: ['id', 'completed'],
+          });
+          const row = res.data?.[0];
+          if (row) {
+            if (!row.completed)
+              await updateSectionProgress({ id: row.id, completed: true });
+          } else {
+            await createSectionProgress({
+              userId,
+              sectionId,
+              completed: true,
+            });
+          }
+        } catch (e) {
+          console.warn('Failed to persist section progress', e);
+        }
+      }
     },
-    [progressId]
+    [progressId, userId]
   );
 
   const markQuestionAnswered = useCallback(
@@ -223,6 +253,8 @@ export function ProgressProvider({ userId, children }: ProviderProps) {
         }
       } catch (e) {
         console.warn('Failed to persist campaign progress', e);
+      } finally {
+        window.dispatchEvent(new Event('campaignProgressChanged'));
       }
     },
     [userId]

--- a/src/hooks/useCampaigns.ts
+++ b/src/hooks/useCampaigns.ts
@@ -86,6 +86,14 @@ export function useCampaigns(userId?: string | null) {
     load();
   }, [load]);
 
+  useEffect(() => {
+    const handler = () => {
+      load();
+    };
+    window.addEventListener('campaignProgressChanged', handler);
+    return () => window.removeEventListener('campaignProgressChanged', handler);
+  }, [load]);
+
   const markCampaignCompleted = useCallback(async (campaignId: string) => {
     if (!userId) return;
 


### PR DESCRIPTION
## Summary
- Broadcast campaign completion events from ProgressContext to refresh CampaignGallery
- Persist section progress centrally and expose section IDs for UI use
- Simplify quiz data hook to remove duplicate progress handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68943f5e0ef8832e891e17b73c0f0dac