### PR TITLE
refactor auth logic in app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,20 +15,16 @@ export default function App() {
 
 function AppContent() {
   const { authStatus } = useAuthenticator((ctx) => [ctx.authStatus]);
-  const [loginTriggered, setLoginTriggered] = useState(false);
+  const [showAuth, setShowAuth] = useState(false);
 
   if (authStatus === 'authenticated') {
     return <AuthenticatedShell />;
   }
 
-  if (!loginTriggered) {
-    return <PublicShell onRequireAuth={() => setLoginTriggered(true)} />;
+  if (showAuth) {
+    return <Authenticator />;
   }
 
-  return (
-    <Authenticator>
-      <AuthenticatedShell />
-    </Authenticator>
-  );
+  return <PublicShell onRequireAuth={() => setShowAuth(true)} />;
 }
 


### PR DESCRIPTION
## Summary
- use `Authenticator.Provider` to supply auth state context
- show authentication UI only when requested using a `showAuth` flag
- switch between public and authenticated shells based on Amplify auth status

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: cannot find module '../amplify_outputs.json'; missing props types)*

------
https://chatgpt.com/codex/tasks/task_e_689442e6bef8832ebb3cfe326eff686b