### PR TITLE
Require auth before answering campaign questions

### DIFF
--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useAuthenticator } from '@aws-amplify/ui-react';
 import { useCampaignQuizData } from '../hooks/useCampaignQuizData';
 import { useProgress } from '../context/ProgressContext';
 import { useActiveCampaign } from '../context/ActiveCampaignContext';
@@ -11,6 +12,7 @@ interface CampaignCanvasProps {
 
 export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvasProps) {
   const { activeCampaignId: campaignId } = useActiveCampaign();
+  const { authStatus } = useAuthenticator((ctx) => [ctx.authStatus]);
 
   const {
     questions,
@@ -49,7 +51,7 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
   const sectionText = current.section ? sectionTextByNumber.get(current.section) : undefined;
 
   const onAnswer = async (answerId: string) => {
-    if (!userId) {
+    if (authStatus !== 'authenticated' || !userId) {
       onRequireAuth?.();
       return;
     }


### PR DESCRIPTION
## Summary
- Use `useAuthenticator` in `CampaignCanvas` to verify authentication before recording answers
- Trigger optional `onRequireAuth` callback when unauthenticated

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689442b37e80832e8bd8d0a7c2854f53