### PR TITLE
Handle service errors and surface loading states

### DIFF
--- a/src/components/CampaignGallery.tsx
+++ b/src/components/CampaignGallery.tsx
@@ -118,7 +118,7 @@ function CampaignCardView({
 function CampaignGalleryInner() {
   const { user } = useAuthenticator((ctx) => [ctx.user]);
   const userId = user?.userId;
-  const { campaigns, loading, refresh } = useCampaigns(userId);
+  const { campaigns, loading, error, refresh } = useCampaigns(userId);
   const { activeCampaignId, setActiveCampaignId } = useActiveCampaign();
   const { completedCampaigns } = useProgress();
 
@@ -142,6 +142,7 @@ function CampaignGalleryInner() {
   }, [campaigns, loading, activeCampaignId, setActiveCampaignId]);
 
   if (loading) return <div>Loading campaigns…</div>;
+  if (error) return <div>Error loading campaigns: {error.message}</div>;
   if (!campaigns?.length) return <div>No campaigns yet.</div>;
 
   return (

--- a/src/components/UserStatsPanel.tsx
+++ b/src/components/UserStatsPanel.tsx
@@ -43,7 +43,11 @@ function getRankForLevel(level: number): { title: string; notes: string; tier: n
 export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanelProps) {
   const { tokens } = useTheme();
   const { xp, level } = useProgress();
-  const { profile } = useUserProfile();
+  const {
+    profile,
+    loading: profileLoading,
+    error: profileError,
+  } = useUserProfile();
   const { user } = useAuthenticator((ctx) => [ctx.user]);
 
   // Defensive defaults
@@ -70,14 +74,29 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
 
   const rank = getRankForLevel(level);
 
+  const containerStyle = {
+    position: 'sticky' as const,
+    top: headerHeight + spacing,
+    maxWidth: '320px',
+  };
+
+  if (profileLoading)
+    return (
+      <View padding={spacing} style={containerStyle}>
+        Loading profile…
+      </View>
+    );
+  if (profileError)
+    return (
+      <View padding={spacing} style={containerStyle}>
+        Error loading profile: {profileError.message}
+      </View>
+    );
+
   return (
     <View
       padding={spacing}
-      style={{
-        position: 'sticky',
-        top: headerHeight + spacing,
-        maxWidth: '320px',
-      }}
+      style={containerStyle}
     >
       <Heading level={3} marginBottom="small">
         User Stats

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -1,22 +1,35 @@
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';
+import { ServiceError } from './serviceError';
 
 const client = generateClient<Schema>();
 
-export function listCampaigns(
+export async function listCampaigns(
   options?: Parameters<typeof client.models.Campaign.list>[0]
 ) {
-  return client.models.Campaign.list(options);
+  try {
+    return await client.models.Campaign.list(options);
+  } catch (err) {
+    throw new ServiceError('Failed to list campaigns', { cause: err });
+  }
 }
 
-export function createCampaign(
+export async function createCampaign(
   input: Parameters<typeof client.models.Campaign.create>[0]
 ) {
-  return client.models.Campaign.create(input);
+  try {
+    return await client.models.Campaign.create(input);
+  } catch (err) {
+    throw new ServiceError('Failed to create campaign', { cause: err });
+  }
 }
 
-export function updateCampaign(
+export async function updateCampaign(
   input: Parameters<typeof client.models.Campaign.update>[0]
 ) {
-  return client.models.Campaign.update(input);
+  try {
+    return await client.models.Campaign.update(input);
+  } catch (err) {
+    throw new ServiceError('Failed to update campaign', { cause: err });
+  }
 }

--- a/src/services/progressService.ts
+++ b/src/services/progressService.ts
@@ -1,61 +1,98 @@
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';
+import { ServiceError } from './serviceError';
 
 const client = generateClient<Schema>();
 
 // CampaignProgress
-export function listCampaignProgress(
+export async function listCampaignProgress(
   options?: Parameters<typeof client.models.CampaignProgress.list>[0]
 ) {
-  return client.models.CampaignProgress.list(options);
+  try {
+    return await client.models.CampaignProgress.list(options);
+  } catch (err) {
+    throw new ServiceError('Failed to list campaign progress', { cause: err });
+  }
 }
 
-export function createCampaignProgress(
+export async function createCampaignProgress(
   input: Parameters<typeof client.models.CampaignProgress.create>[0]
 ) {
-  return client.models.CampaignProgress.create(input);
+  try {
+    return await client.models.CampaignProgress.create(input);
+  } catch (err) {
+    throw new ServiceError('Failed to create campaign progress', { cause: err });
+  }
 }
 
-export function updateCampaignProgress(
+export async function updateCampaignProgress(
   input: Parameters<typeof client.models.CampaignProgress.update>[0]
 ) {
-  return client.models.CampaignProgress.update(input);
+  try {
+    return await client.models.CampaignProgress.update(input);
+  } catch (err) {
+    throw new ServiceError('Failed to update campaign progress', { cause: err });
+  }
 }
 
 // SectionProgress
-export function listSectionProgress(
+export async function listSectionProgress(
   options?: Parameters<typeof client.models.SectionProgress.list>[0]
 ) {
-  return client.models.SectionProgress.list(options);
+  try {
+    return await client.models.SectionProgress.list(options);
+  } catch (err) {
+    throw new ServiceError('Failed to list section progress', { cause: err });
+  }
 }
 
-export function createSectionProgress(
+export async function createSectionProgress(
   input: Parameters<typeof client.models.SectionProgress.create>[0]
 ) {
-  return client.models.SectionProgress.create(input);
+  try {
+    return await client.models.SectionProgress.create(input);
+  } catch (err) {
+    throw new ServiceError('Failed to create section progress', { cause: err });
+  }
 }
 
-export function updateSectionProgress(
+export async function updateSectionProgress(
   input: Parameters<typeof client.models.SectionProgress.update>[0]
 ) {
-  return client.models.SectionProgress.update(input);
+  try {
+    return await client.models.SectionProgress.update(input);
+  } catch (err) {
+    throw new ServiceError('Failed to update section progress', { cause: err });
+  }
 }
 
 // UserProgress
-export function listUserProgress(
+export async function listUserProgress(
   options?: Parameters<typeof client.models.UserProgress.list>[0]
 ) {
-  return client.models.UserProgress.list(options);
+  try {
+    return await client.models.UserProgress.list(options);
+  } catch (err) {
+    throw new ServiceError('Failed to list user progress', { cause: err });
+  }
 }
 
-export function createUserProgress(
+export async function createUserProgress(
   input: Parameters<typeof client.models.UserProgress.create>[0]
 ) {
-  return client.models.UserProgress.create(input);
+  try {
+    return await client.models.UserProgress.create(input);
+  } catch (err) {
+    throw new ServiceError('Failed to create user progress', { cause: err });
+  }
 }
 
-export function updateUserProgress(
+export async function updateUserProgress(
   input: Parameters<typeof client.models.UserProgress.update>[0]
 ) {
-  return client.models.UserProgress.update(input);
+  try {
+    return await client.models.UserProgress.update(input);
+  } catch (err) {
+    throw new ServiceError('Failed to update user progress', { cause: err });
+  }
 }

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -1,22 +1,35 @@
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';
+import { ServiceError } from './serviceError';
 
 const client = generateClient<Schema>();
 
-export function listQuestions(
+export async function listQuestions(
   options?: Parameters<typeof client.models.Question.list>[0]
 ) {
-  return client.models.Question.list(options);
+  try {
+    return await client.models.Question.list(options);
+  } catch (err) {
+    throw new ServiceError('Failed to list questions', { cause: err });
+  }
 }
 
-export function createQuestion(
+export async function createQuestion(
   input: Parameters<typeof client.models.Question.create>[0]
 ) {
-  return client.models.Question.create(input);
+  try {
+    return await client.models.Question.create(input);
+  } catch (err) {
+    throw new ServiceError('Failed to create question', { cause: err });
+  }
 }
 
-export function updateQuestion(
+export async function updateQuestion(
   input: Parameters<typeof client.models.Question.update>[0]
 ) {
-  return client.models.Question.update(input);
+  try {
+    return await client.models.Question.update(input);
+  } catch (err) {
+    throw new ServiceError('Failed to update question', { cause: err });
+  }
 }

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -1,22 +1,35 @@
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';
+import { ServiceError } from './serviceError';
 
 const client = generateClient<Schema>();
 
-export function listSections(
+export async function listSections(
   options?: Parameters<typeof client.models.Section.list>[0]
 ) {
-  return client.models.Section.list(options);
+  try {
+    return await client.models.Section.list(options);
+  } catch (err) {
+    throw new ServiceError('Failed to list sections', { cause: err });
+  }
 }
 
-export function createSection(
+export async function createSection(
   input: Parameters<typeof client.models.Section.create>[0]
 ) {
-  return client.models.Section.create(input);
+  try {
+    return await client.models.Section.create(input);
+  } catch (err) {
+    throw new ServiceError('Failed to create section', { cause: err });
+  }
 }
 
-export function updateSection(
+export async function updateSection(
   input: Parameters<typeof client.models.Section.update>[0]
 ) {
-  return client.models.Section.update(input);
+  try {
+    return await client.models.Section.update(input);
+  } catch (err) {
+    throw new ServiceError('Failed to update section', { cause: err });
+  }
 }

--- a/src/services/serviceError.ts
+++ b/src/services/serviceError.ts
@@ -1,0 +1,6 @@
+export class ServiceError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'ServiceError';
+  }
+}

--- a/src/services/userProfileService.ts
+++ b/src/services/userProfileService.ts
@@ -1,22 +1,35 @@
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';
+import { ServiceError } from './serviceError';
 
 const client = generateClient<Schema>();
 
-export function listUserProfiles(
+export async function listUserProfiles(
   options?: Parameters<typeof client.models.UserProfile.list>[0]
 ) {
-  return client.models.UserProfile.list(options);
+  try {
+    return await client.models.UserProfile.list(options);
+  } catch (err) {
+    throw new ServiceError('Failed to list user profiles', { cause: err });
+  }
 }
 
-export function createUserProfile(
+export async function createUserProfile(
   input: Parameters<typeof client.models.UserProfile.create>[0]
 ) {
-  return client.models.UserProfile.create(input);
+  try {
+    return await client.models.UserProfile.create(input);
+  } catch (err) {
+    throw new ServiceError('Failed to create user profile', { cause: err });
+  }
 }
 
-export function updateUserProfile(
+export async function updateUserProfile(
   input: Parameters<typeof client.models.UserProfile.update>[0]
 ) {
-  return client.models.UserProfile.update(input);
+  try {
+    return await client.models.UserProfile.update(input);
+  } catch (err) {
+    throw new ServiceError('Failed to update user profile', { cause: err });
+  }
 }


### PR DESCRIPTION
## Summary
- add shared `ServiceError` and wrap all service calls in try/catch
- surface loading and error state in `useCampaigns` and `useUserProfile`
- display campaign/profile load errors in UI components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68944533e15c832ebc4af18c8b2545b8