### PR TITLE
feat: use "Friend" as default user name

### DIFF
--- a/src/components/UserStatsPanel.tsx
+++ b/src/components/UserStatsPanel.tsx
@@ -60,7 +60,7 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
     (typeof profile?.displayName === 'string' && profile.displayName) ||
     user?.username ||
     loginId ||
-    'N/A';
+    'Friend';
 
   const email =
     (typeof profile?.email === 'string' && profile.email) ||


### PR DESCRIPTION
## Summary
- show "Friend" when no display name or login ID

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68944b11293c832e9a6377943d8b61e9