### PR TITLE
feat: prompt user for display name

### DIFF
--- a/src/components/DisplayNamePrompt.tsx
+++ b/src/components/DisplayNamePrompt.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { Card, Button, Heading, TextField } from '@aws-amplify/ui-react';
+import { useUserProfile } from '../context/UserProfileContext';
+
+const STORAGE_KEY = 'displayNameSet';
+
+export default function DisplayNamePrompt() {
+  const { profile, updateDisplayName, loading } = useUserProfile();
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [completed, setCompleted] = useState(false);
+
+  useEffect(() => {
+    if (profile?.displayName || localStorage.getItem(STORAGE_KEY)) {
+      setCompleted(true);
+    }
+  }, [profile]);
+
+  if (loading || completed) return null;
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (/^[a-zA-Z0-9]*$/.test(value) && value.length <= 20) {
+      setName(value);
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!/^[a-zA-Z0-9]{3,20}$/.test(name)) {
+      setError('Name must be 3-20 alphanumeric characters.');
+      return;
+    }
+    try {
+      await updateDisplayName(name);
+      localStorage.setItem(STORAGE_KEY, 'true');
+      setCompleted(true);
+    } catch {
+      setError('Failed to save name.');
+    }
+  };
+
+  return (
+    <Card variation="elevated" marginBottom="large" padding="large">
+      <Heading level={4} marginBottom="small">
+        Choose a display name
+      </Heading>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', gap: 8 }}>
+        <TextField
+          label="Display name"
+          value={name}
+          onChange={onChange}
+          placeholder="Display name"
+          maxLength={20}
+        />
+        <Button type="submit">Save</Button>
+      </form>
+      {error && (
+        <div style={{ color: 'red', marginTop: 8 }}>{error}</div>
+      )}
+    </Card>
+  );
+}
+

--- a/src/pages/AuthenticatedShell.tsx
+++ b/src/pages/AuthenticatedShell.tsx
@@ -15,6 +15,7 @@ import { useHeaderHeight } from '../hooks/useHeaderHeight';
 import { ProgressProvider } from '../context/ProgressContext';
 import { ActiveCampaignProvider } from '../context/ActiveCampaignContext';
 import { UserProfileProvider } from '../context/UserProfileContext';
+import DisplayNamePrompt from '../components/DisplayNamePrompt';
 
 export default function AuthenticatedShell() {
   const { user, signOut, authStatus } = useAuthenticator((ctx) => [ctx.user, ctx.authStatus]);
@@ -58,6 +59,7 @@ export default function AuthenticatedShell() {
     <UserProfileProvider userId={userId} email={emailFromAttrs}>
       <ActiveCampaignProvider>
         <ProgressProvider userId={userId}>
+          <DisplayNamePrompt />
           <div style={gridStyle}>
             <div style={{ gridArea: 'header' }}>
               <HeaderBar ref={headerRef} signOut={signOut} />


### PR DESCRIPTION
## Summary
- add DisplayNamePrompt component to capture a user's display name once
- render the prompt in AuthenticatedShell before the main UI if no name is set

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module '../amplify_outputs.json', type errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68944b1f79d8832ebe6f6d8da03d6b73