### PR TITLE
feat: show section titles on campaign canvas

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -221,6 +221,20 @@ main {
   margin-top: 0.5rem;
 }
 
+/* Title and text styling for current quiz section */
+.current-section-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0.5rem 0;
+  color: #1e2a3a;
+}
+
+.current-section-text {
+  margin: 0 0 1rem;
+  color: #555;
+  font-style: italic;
+}
+
 /* ============================
    Modal (SetDisplayNameModal)
 ============================ */

--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -14,8 +14,14 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
   const { activeCampaignId: campaignId } = useActiveCampaign();
   const { authStatus } = useAuthenticator((ctx) => [ctx.authStatus]);
 
-  const { questions, sectionTextByNumber, loading, error, sectionIdByNumber } =
-    useCampaignQuizData(campaignId);
+  const {
+    questions,
+    sectionTextByNumber,
+    sectionTitleByNumber,
+    loading,
+    error,
+    sectionIdByNumber,
+  } = useCampaignQuizData(campaignId);
 
   const {
     handleAnswer,
@@ -42,7 +48,12 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
     return <div>Campaign complete, {profile?.displayName ?? 'Friend'}!</div>;
 
   const current = questions[index];
-  const sectionText = current.section ? sectionTextByNumber.get(current.section) : undefined;
+  const sectionTitle = current.section
+    ? sectionTitleByNumber.get(current.section)
+    : undefined;
+  const sectionText = current.section
+    ? sectionTextByNumber.get(current.section)
+    : undefined;
 
   const onAnswer = async (answerId: string) => {
     if (authStatus !== 'authenticated' || !userId) {
@@ -84,7 +95,8 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
 
   return (
     <div data-campaign-id={campaignId ?? ''} data-user-id={userId}>
-      {sectionText && <p>{sectionText}</p>}
+      {sectionTitle && <h3 className="current-section-title">{sectionTitle}</h3>}
+      {sectionText && <p className="current-section-text">{sectionText}</p>}
 
       <div className="question-item">
         <p>{current.text}</p>

--- a/src/hooks/useCampaignQuizData.ts
+++ b/src/hooks/useCampaignQuizData.ts
@@ -16,6 +16,7 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
   const [orderedSectionNumbers, setOrderedSectionNumbers] = useState<number[]>([]);
   const [sectionIdByNumber, setSectionIdByNumber] = useState<Map<number, string>>(new Map());
   const [sectionTextByNumber, setSectionTextByNumber] = useState<Map<number, string>>(new Map());
+  const [sectionTitleByNumber, setSectionTitleByNumber] = useState<Map<number, string>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setErr] = useState<Error | null>(null);
 
@@ -36,7 +37,7 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
       try {
         const sRes = await listSections({
           filter: { campaignId: { eq: campaignId } },
-          selectionSet: ['id', 'number', 'order', 'educationalText', 'isActive'],
+          selectionSet: ['id', 'number', 'order', 'educationalText', 'title', 'isActive'],
         });
 
         const sections = (sRes.data ?? [])
@@ -44,20 +45,23 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
           .sort((a, b) => (a.order ?? a.number ?? 0) - (b.order ?? b.number ?? 0));
 
         const numToId = new Map<number, string>();
-        // Track section educational text by section number (bug fix: single source of truth)
+        // Track section educational text and titles by section number (bug fix: single source of truth)
         const textByNum = new Map<number, string>();
+        const titleByNum = new Map<number, string>();
         const orderedNums: number[] = [];
 
         for (const s of sections) {
           const n = (s.number ?? 0) as number;
           numToId.set(n, s.id);
           textByNum.set(n, s.educationalText ?? '');
+          titleByNum.set(n, s.title ?? '');
           orderedNums.push(n);
         }
 
         if (cancelled) return;
         setSectionIdByNumber(numToId);
         setSectionTextByNumber(textByNum);
+        setSectionTitleByNumber(titleByNum);
         setOrderedSectionNumbers(orderedNums);
 
         const sectionIds = sections.map((s) => s.id);
@@ -112,6 +116,7 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
       setOrderedSectionNumbers([]);
       setSectionIdByNumber(new Map());
       setSectionTextByNumber(new Map());
+      setSectionTitleByNumber(new Map());
       setLoading(false);
       return;
     }
@@ -128,6 +133,7 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
     error,
     orderedSectionNumbers,
     sectionTextByNumber,
+    sectionTitleByNumber,
     sectionIdByNumber,
   };
 }


### PR DESCRIPTION
## Summary
- include section titles in quiz data fetching and expose map of titles by section
- display section title above educational text on the campaign canvas
- add styling to distinguish section titles from educational text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module '../amplify_outputs.json' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68944b797968832ead0852d88093a192