### PR TITLE
refactor: replace answers with typed responses

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -3,7 +3,7 @@ import { type ClientSchema, a, defineData } from '@aws-amplify/backend';
 
 const schema = a.schema({
   // ------------------------------------------------------------
-  // Content hierarchy: Campaign -> Section -> Question -> Answer
+  // Content hierarchy: Campaign -> Section -> Question
   // ------------------------------------------------------------
 
   Campaign: a
@@ -67,21 +67,11 @@ const schema = a.schema({
       order: a.integer().default(0),
       isActive: a.boolean().default(true),
 
-      answers: a.hasMany('Answer', 'questionId'),
-    })
-    .authorization((allow) => [
-      allow.authenticated().to(['read']),
-    ]),
+      correctAnswer: a.string().required(),
+      hint: a.string(),
+      explanation: a.string(),
 
-  Answer: a
-    .model({
-      id: a.id().required(),
-      questionId: a.id().required(),
-      question: a.belongsTo('Question', 'questionId'),
-      content: a.string().required(),
-      isCorrect: a.boolean().default(false),
-      order: a.integer().default(0),
-      isActive: a.boolean().default(true),
+      responses: a.hasMany('UserResponse', 'questionId'),
     })
     .authorization((allow) => [
       allow.authenticated().to(['read']),
@@ -98,6 +88,19 @@ const schema = a.schema({
       email: a.string(),
       displayName: a.string(),
       avatarUrl: a.string(),
+    })
+    .authorization((allow) => [
+      allow.owner().to(['create', 'read', 'update', 'delete']),
+    ]),
+
+  UserResponse: a
+    .model({
+      id: a.id().required(),
+      userId: a.string().required(),
+      questionId: a.id().required(),
+      question: a.belongsTo('Question', 'questionId'),
+      responseText: a.string().required(),
+      isCorrect: a.boolean().required(),
     })
     .authorization((allow) => [
       allow.owner().to(['create', 'read', 'update', 'delete']),

--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -28,6 +28,7 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
   const { profile } = useUserProfile();
 
   const [index, setIndex] = useState(0);
+  const [response, setResponse] = useState('');
 
   // Reset index when campaign or questions change
   useEffect(() => {
@@ -44,16 +45,17 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
   const current = questions[index];
   const sectionText = current.section ? sectionTextByNumber.get(current.section) : undefined;
 
-  const onAnswer = async (answerId: string) => {
+  const onSubmit = async () => {
     if (authStatus !== 'authenticated' || !userId) {
       onRequireAuth?.();
       return;
     }
-    const ans = current.answers.find((a) => a.id === answerId);
-    const isCorrect = !!ans?.isCorrect;
+    const isCorrect =
+      response.trim().toLowerCase() === current.correctAnswer.trim().toLowerCase();
 
     await handleAnswer({
       questionId: current.id,
+      responseText: response,
       isCorrect,
       xp: current.xpValue ?? undefined,
     });
@@ -79,6 +81,7 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
       }
     }
 
+    setResponse('');
     setIndex((prev) => prev + 1);
   };
 
@@ -88,11 +91,12 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
 
       <div className="question-item">
         <p>{current.text}</p>
-        {current.answers.map((a) => (
-          <button key={a.id} onClick={() => onAnswer(a.id)}>
-            {a.content}
-          </button>
-        ))}
+        <input
+          type="text"
+          value={response}
+          onChange={(e) => setResponse(e.target.value)}
+        />
+        <button onClick={onSubmit}>Submit</button>
       </div>
     </div>
   );

--- a/src/context/ProgressContext.tsx
+++ b/src/context/ProgressContext.tsx
@@ -20,6 +20,7 @@ import {
   createSectionProgress,
   updateSectionProgress,
 } from '../services/progressService';
+import { createUserResponse } from '../services/userResponseService';
 import type { Schema } from '../../amplify/data/resource';
 import { getLevelFromXP } from '../utils/xp';
 import type { HandleAnswer, SubmitArgs } from '../types/QuestionTypes';
@@ -233,13 +234,20 @@ export function ProgressProvider({ userId, children }: ProviderProps) {
   );
 
   const handleAnswer: HandleAnswer = useCallback(
-    ({ questionId, isCorrect, xp = 0 }: SubmitArgs) => {
+    async ({ questionId, responseText, isCorrect, xp = 0 }: SubmitArgs) => {
+      createUserResponse({
+        userId,
+        questionId,
+        responseText,
+        isCorrect,
+      }).catch((e) => console.warn('Failed to record response', e));
+
       if (!isCorrect) return;
       const alreadyAnswered = answeredQuestions.includes(questionId);
       if (!alreadyAnswered) awardXP(xp);
       markQuestionAnswered(questionId);
     },
-    [answeredQuestions, awardXP, markQuestionAnswered]
+    [answeredQuestions, awardXP, markQuestionAnswered, userId]
   );
 
   const markCampaignComplete = useCallback(

--- a/src/hooks/useCampaignQuizData.ts
+++ b/src/hooks/useCampaignQuizData.ts
@@ -73,7 +73,7 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
           ...(qFilter ? { filter: qFilter } : {}),
           selectionSet: [
             'id', 'text', 'section', 'xpValue', 'sectionRef.number',
-            'answers.id', 'answers.content', 'answers.isCorrect',
+            'correctAnswer', 'hint', 'explanation',
           ],
         });
 
@@ -84,18 +84,18 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
             section?: number | null;
             sectionRef?: { number?: number | null } | null;
             xpValue?: number | null;
-            answers?: { id: string; content: string; isCorrect?: boolean | null }[];
+            correctAnswer: string;
+            hint?: string | null;
+            explanation?: string | null;
           };
           return {
             id: row.id,
             text: row.text,
             section: (row.section ?? row.sectionRef?.number ?? 0) as number,
             xpValue: row.xpValue ?? 10,
-            answers: (row.answers ?? []).map((ans) => ({
-              id: ans.id,
-              content: ans.content,
-              isCorrect: !!ans.isCorrect,
-            })),
+            correctAnswer: row.correctAnswer,
+            hint: row.hint ?? undefined,
+            explanation: row.explanation ?? undefined,
           };
         });
         if (!cancelled) setQuestions(qs);

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -33,3 +33,13 @@ export async function updateQuestion(
     throw new ServiceError('Failed to update question', { cause: err });
   }
 }
+
+export async function deleteQuestion(
+  input: Parameters<typeof client.models.Question.delete>[0]
+) {
+  try {
+    return await client.models.Question.delete(input);
+  } catch (err) {
+    throw new ServiceError('Failed to delete question', { cause: err });
+  }
+}

--- a/src/services/userResponseService.ts
+++ b/src/services/userResponseService.ts
@@ -1,0 +1,35 @@
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../amplify/data/resource';
+import { ServiceError } from './serviceError';
+
+const client = generateClient<Schema>();
+
+export async function listUserResponses(
+  options?: Parameters<typeof client.models.UserResponse.list>[0]
+) {
+  try {
+    return await client.models.UserResponse.list(options);
+  } catch (err) {
+    throw new ServiceError('Failed to list user responses', { cause: err });
+  }
+}
+
+export async function createUserResponse(
+  input: Parameters<typeof client.models.UserResponse.create>[0]
+) {
+  try {
+    return await client.models.UserResponse.create(input);
+  } catch (err) {
+    throw new ServiceError('Failed to create user response', { cause: err });
+  }
+}
+
+export async function updateUserResponse(
+  input: Parameters<typeof client.models.UserResponse.update>[0]
+) {
+  try {
+    return await client.models.UserResponse.update(input);
+  } catch (err) {
+    throw new ServiceError('Failed to update user response', { cause: err });
+  }
+}

--- a/src/types/QuestionTypes.ts
+++ b/src/types/QuestionTypes.ts
@@ -1,12 +1,6 @@
 /**
- * Shared quiz question and answer type definitions.
+ * Shared quiz question type definitions.
  */
-
-export interface Answer {
-  id: string;
-  content: string;
-  isCorrect: boolean;
-}
 
 export interface Question {
   id: string;
@@ -14,11 +8,14 @@ export interface Question {
   section: number;
   xpValue?: number | null;
   educationalText?: string;
-  answers: Answer[];
+  correctAnswer: string;
+  hint?: string;
+  explanation?: string;
 }
 
 export interface SubmitArgs {
   questionId: string;
+  responseText: string;
   isCorrect: boolean;
   xp?: number;
 }


### PR DESCRIPTION
## Summary
- remove multiple choice Answer model in favor of single-field questions with optional hint/explanation
- add UserResponse model and service to persist typed answers
- adapt client types, hooks, and components for typed responses and capture user answers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module '../amplify_outputs.json' etc)*

------
https://chatgpt.com/codex/tasks/task_e_68944ceadb64832eb0d34e5cf3084392