### PR TITLE
Default questions to written type

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -63,6 +63,8 @@ const schema = a.schema({
       sectionRef: a.belongsTo('Section', 'sectionId'),
 
       text: a.string().required(),
+      // Default to 'written' until enum default support is available
+      type: a.string().default('written'),
       xpValue: a.integer().default(10),
       difficulty: a.enum(['easy', 'medium', 'hard']),
       order: a.integer().default(0),

--- a/src/hooks/useCampaignQuizData.ts
+++ b/src/hooks/useCampaignQuizData.ts
@@ -76,7 +76,7 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
         const qRes = await listQuestions({
           ...(qFilter ? { filter: qFilter } : {}),
           selectionSet: [
-            'id', 'text', 'section', 'xpValue', 'sectionRef.number',
+            'id', 'text', 'type', 'section', 'xpValue', 'sectionRef.number',
             'correctAnswer', 'hint', 'explanation',
           ],
         });
@@ -85,6 +85,7 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
           const row = q as unknown as {
             id: string;
             text: string;
+            type?: 'multipleChoice' | 'written' | null;
             section?: number | null;
             sectionRef?: { number?: number | null } | null;
             xpValue?: number | null;
@@ -95,6 +96,7 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
           return {
             id: row.id,
             text: row.text,
+            type: (row.type ?? 'written') as 'multipleChoice' | 'written',
             section: (row.section ?? row.sectionRef?.number ?? 0) as number,
             xpValue: row.xpValue ?? 10,
             correctAnswer: row.correctAnswer,

--- a/src/types/QuestionTypes.ts
+++ b/src/types/QuestionTypes.ts
@@ -6,6 +6,7 @@ export interface Question {
   id: string;
   text: string;
   section: number;
+  type: 'multipleChoice' | 'written';
   xpValue?: number | null;
   educationalText?: string;
   correctAnswer: string;
@@ -18,7 +19,6 @@ export interface SubmitArgs {
   responseText: string;
   isCorrect: boolean;
   xp?: number;
-  responseText?: string;
   sectionId?: string;
 }
 


### PR DESCRIPTION
## Summary
- default Question.type to "written" in backend schema
- load question types in quiz data hook with written fallback
- require question type in shared types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: An object literal cannot have multiple properties with the same name)*

------
https://chatgpt.com/codex/tasks/task_e_6894512384dc832e97f18c8e6fdf43bd