### PR TITLE
Remove duplicate UserResponse schema model

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -147,18 +147,6 @@ const schema = a.schema({
       allow.owner().to(['create', 'read', 'update', 'delete']),
     ]),
 
-  UserResponse: a
-    .model({
-      id: a.id().required(),
-      userId: a.string().required(),
-      questionId: a.id().required(),
-      responseText: a.string(),
-      isCorrect: a.boolean().default(false),
-    })
-    .authorization((allow) => [
-      allow.owner().to(['create', 'read', 'update', 'delete']),
-    ]),
-
   // Optional legacy model
   UserStats: a
     .model({


### PR DESCRIPTION
## Summary
- remove duplicate UserResponse model from Amplify data schema
- regenerate Amplify types

## Testing
- `npx ampx generate`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68945813abf8832e8fc8e690e03c02b2