### PR TITLE
feat: broadcast progress events for banner

### DIFF
--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -18,13 +18,8 @@ export default function AnnouncementBanner({ onLevelUp, onDismiss }: Announcemen
   const currentRef = useRef<ProgressEvent | null>(null);
   const dismissedRef = useRef(false);
 
-  useEffect(() => {
-    currentRef.current = current;
-  }, [current]);
-
-  useEffect(() => {
-    dismissedRef.current = dismissed;
-  }, [dismissed]);
+  currentRef.current = current;
+  dismissedRef.current = dismissed;
 
   useEffect(() => {
     const unsub = subscribe((evt) => {
@@ -37,7 +32,7 @@ export default function AnnouncementBanner({ onLevelUp, onDismiss }: Announcemen
         queue.current.push(evt);
       }
     });
-    return unsub;
+    return () => unsub();
   }, [subscribe]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- emit progress events from ProgressContext for sections, campaigns, and level-ups
- listen for progress events in AnnouncementBanner to show dismissible XP banners

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689457f75fa0832e8c255d50fa59bf3b