### PR TITLE
Add title model and show player titles

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -78,6 +78,16 @@ const schema = a.schema({
       allow.authenticated().to(['read']),
     ]),
 
+  Title: a
+    .model({
+      id: a.id().required(),
+      name: a.string().required(),
+      minLevel: a.integer().required(),
+    })
+    .authorization((allow) => [
+      allow.authenticated().to(['read']),
+    ]),
+
   // ------------------------------------------------------------
   // User-owned state and progress
   // ------------------------------------------------------------

--- a/src/components/UserStatsPanel.tsx
+++ b/src/components/UserStatsPanel.tsx
@@ -24,25 +24,9 @@ interface UserStatsPanelProps {
   spacing: number;
 }
 
-/** Map user level → Title + Notes (from your table) */
-function getRankForLevel(level: number): { title: string; notes: string; tier: number } {
-  if (level >= 91) return { tier: 12, title: 'Eternal Keeper of Secrets', notes: 'Final endgame grind' };
-  if (level >= 71) return { tier: 11, title: 'Mythic Treasure Hunter', notes: 'Big prestige; XP curve steep' };
-  if (level >= 61) return { tier: 10, title: 'Legendary Expedition Leader', notes: 'Small player % reach here' };
-  if (level >= 51) return { tier: 9, title: 'Lost City Adventurer', notes: 'Feels elite' };
-  if (level >= 41) return { tier: 8, title: 'Tomb Raider', notes: 'Start of serious grind' };
-  if (level >= 31) return { tier: 7, title: 'Artifact Appraiser', notes: 'More commitment required' };
-  if (level >= 21) return { tier: 6, title: 'Crypt Delver', notes: 'Mid-game pace' };
-  if (level >= 16) return { tier: 5, title: 'Temple Cartographer', notes: 'Starts feeling like an achievement' };
-  if (level >= 11) return { tier: 4, title: 'Ruins Explorer', notes: 'Slightly longer per level' };
-  if (level >= 6) return { tier: 3, title: 'Jungle Scout', notes: 'Still feels quick' };
-  if (level >= 2) return { tier: 2, title: 'Desert Pathfinder', notes: 'Very fast to get' };
-  return { tier: 1, title: 'Novice Relic Seeker', notes: 'First login/first XP gain' };
-}
-
 export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanelProps) {
   const { tokens } = useTheme();
-  const { xp, level } = useProgress();
+  const { xp, level, title } = useProgress();
   const {
     profile,
     loading: profileLoading,
@@ -71,8 +55,6 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
   const progressWithinLevel = getXPWithinLevel(safeXP, XP_PER_LEVEL);
   const levelPercent = calculateXPProgress(progressWithinLevel, XP_PER_LEVEL);
   const nextLevelIn = getXPToNextLevel(safeXP, XP_PER_LEVEL);
-
-  const rank = getRankForLevel(level);
 
   const containerStyle = {
     position: 'sticky' as const,
@@ -116,7 +98,12 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
         </Text>
       </Flex>
 
-      <XPBar percent={levelPercent} label={`Progress to Level ${level + 1}`} fillColor="#e7bb73" />
+      <XPBar
+        percent={levelPercent}
+        label={`Progress to Level ${level + 1}`}
+        title={title}
+        fillColor="#e7bb73"
+      />
 
       <Text marginTop="xs" color={tokens.colors.font.secondary} fontSize="0.9rem">
         {nextLevelIn === 0
@@ -126,14 +113,13 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
 
       <Divider marginTop="medium" marginBottom="small" />
 
-      {/* Dynamic Rank Title */}
       <Flex
         direction="column"
         gap="0.25rem"
         padding="0.75rem"
         borderRadius="0.75rem"
         style={{
-          background: 'rgba(231,187,115,0.12)', // subtle gold tint
+          background: 'rgba(231,187,115,0.12)',
           border: '1px solid rgba(231,187,115,0.35)',
         }}
         marginBottom="small"
@@ -145,10 +131,7 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
           fontWeight={800}
           style={{ fontSize: '1.05rem', color: '#e7bb73', lineHeight: 1.1 }}
         >
-          {rank.tier} – {rank.title}
-        </Text>
-        <Text fontSize="0.85rem" color={tokens.colors.font.secondary}>
-          {rank.notes}
+          {title}
         </Text>
       </Flex>
 

--- a/src/components/XPBar.tsx
+++ b/src/components/XPBar.tsx
@@ -6,10 +6,12 @@ export default function XPBar({
   percent, // 0..100 (fractional allowed)
   label,
   fillColor = '#e7bb73', // gold to match header titles
+  title,
 }: {
   percent: number;
   label?: string;
   fillColor?: string;
+  title?: string;
 }) {
   const { tokens } = useTheme();
 
@@ -30,13 +32,22 @@ export default function XPBar({
       style={{ width: '100%' }}
     >
       {label && (
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+        <div
+          style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}
+        >
           <Text fontSize="0.85rem" color={tokens.colors.font.secondary}>
             {label}
           </Text>
-          <Text fontSize="0.85rem" color={tokens.colors.font.secondary}>
-            {shown}%
-          </Text>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {title && (
+              <Text fontSize="0.85rem" color={tokens.colors.font.secondary}>
+                {title}
+              </Text>
+            )}
+            <Text fontSize="0.85rem" color={tokens.colors.font.secondary}>
+              {shown}%
+            </Text>
+          </div>
         </div>
       )}
 

--- a/src/services/titleService.ts
+++ b/src/services/titleService.ts
@@ -1,0 +1,15 @@
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../amplify/data/resource';
+import { ServiceError } from './serviceError';
+
+const client = generateClient<Schema>();
+
+export async function listTitles(
+  options: Parameters<typeof client.models.Title.list>[0] = {}
+) {
+  try {
+    return await client.models.Title.list(options);
+  } catch (err) {
+    throw new ServiceError('Failed to list titles', { cause: err });
+  }
+}


### PR DESCRIPTION
## Summary
- add `Title` data model for configurable player titles
- fetch and cache titles in ProgressContext
- display current title beside XP progress bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: TS1117: An object literal cannot have multiple properties with the same name, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689457fb01fc832ebd14c9df35e6f3f3