### PR TITLE
Implement dynamic XP scaling with level cap

### DIFF
--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Card, Button, Heading, Text } from '@aws-amplify/ui-react';
 import { useProgress } from '../context/ProgressContext';
 import {
-  XP_PER_LEVEL,
+  xpForLevel,
   getXPWithinLevel,
   calculateXPProgress,
 } from '../utils/xp';
@@ -42,10 +42,16 @@ export default function AnnouncementBanner({ onLevelUp, onDismiss }: Announcemen
       newDesc = `${count} completed section${count === 1 ? '' : 's'}!`;
       newIndicator = '✓';
     } else if (xp > prevXP.current) {
-      const currentXP = getXPWithinLevel(xp, XP_PER_LEVEL);
-      const pct = Math.round(calculateXPProgress(currentXP, XP_PER_LEVEL));
+      const currentXP = getXPWithinLevel(xp);
+      const required = xpForLevel(level);
+      const pct = Math.round(
+        calculateXPProgress(
+          currentXP,
+          Number.isFinite(required) ? required : 1,
+        ),
+      );
       newTitle = 'Leveling up!';
-      newDesc = `You’ve earned ${currentXP} XP toward ${XP_PER_LEVEL}. Keep going to unlock the next section.`;
+      newDesc = `You’ve earned ${currentXP} XP toward ${required}. Keep going to unlock the next section.`;
       newIndicator = `${pct}%`;
     }
 

--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -44,15 +44,18 @@ export default function AnnouncementBanner({ onLevelUp, onDismiss }: Announcemen
     } else if (xp > prevXP.current) {
       const currentXP = getXPWithinLevel(xp);
       const required = xpForLevel(level);
-      const pct = Math.round(
-        calculateXPProgress(
-          currentXP,
-          Number.isFinite(required) ? required : 1,
-        ),
-      );
-      newTitle = 'Leveling up!';
-      newDesc = `You’ve earned ${currentXP} XP toward ${required}. Keep going to unlock the next section.`;
-      newIndicator = `${pct}%`;
+      if (!Number.isFinite(required)) {
+        newTitle = 'Max level reached!';
+        newDesc = 'You have hit the level cap.';
+        newIndicator = String(level);
+      } else {
+        const pct = Math.round(
+          calculateXPProgress(currentXP, required),
+        );
+        newTitle = 'Leveling up!';
+        newDesc = `You’ve earned ${currentXP} XP toward ${required}. Keep going to unlock the next section.`;
+        newIndicator = `${pct}%`;
+      }
     }
 
     if (newTitle) {

--- a/src/components/UserStatsPanel.tsx
+++ b/src/components/UserStatsPanel.tsx
@@ -70,11 +70,14 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
   // Per-level math
   const requiredXP = xpForLevel(level);
   const progressWithinLevel = getXPWithinLevel(safeXP);
-  const levelPercent = calculateXPProgress(
-    progressWithinLevel,
-    Number.isFinite(requiredXP) ? requiredXP : 1,
-  );
-  const nextLevelIn = getXPToNextLevel(safeXP);
+  const levelPercent =
+    level >= 160
+      ? 100
+      : calculateXPProgress(
+          progressWithinLevel,
+          Number.isFinite(requiredXP) ? requiredXP : 1,
+        );
+  const nextLevelIn = level >= 160 ? 0 : getXPToNextLevel(safeXP);
 
   const rank = getRankForLevel(level);
 
@@ -121,10 +124,16 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
         </Text>
       </Flex>
 
-      <XPBar percent={levelPercent} label={`Progress to Level ${level + 1}`} fillColor="#e7bb73" />
+      <XPBar
+        percent={levelPercent}
+        label={level >= 160 ? 'Max Level' : `Progress to Level ${level + 1}`}
+        fillColor="#e7bb73"
+      />
 
       <Text marginTop="xs" color={tokens.colors.font.secondary} fontSize="0.9rem">
-        {nextLevelIn === 0
+        {level >= 160
+          ? 'Maximum level achieved — congrats!'
+          : nextLevelIn === 0
           ? 'Level up ready — keep going!'
           : `Only ${nextLevelIn} XP to reach Level ${level + 1}`}
       </Text>

--- a/src/components/UserStatsPanel.tsx
+++ b/src/components/UserStatsPanel.tsx
@@ -12,7 +12,7 @@ import {
 import { useProgress } from '../context/ProgressContext';
 import { useUserProfile } from '../context/UserProfileContext';
 import {
-  XP_PER_LEVEL,
+  xpForLevel,
   getXPWithinLevel,
   calculateXPProgress,
   getXPToNextLevel,
@@ -68,9 +68,13 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
     'N/A';
 
   // Per-level math
-  const progressWithinLevel = getXPWithinLevel(safeXP, XP_PER_LEVEL);
-  const levelPercent = calculateXPProgress(progressWithinLevel, XP_PER_LEVEL);
-  const nextLevelIn = getXPToNextLevel(safeXP, XP_PER_LEVEL);
+  const requiredXP = xpForLevel(level);
+  const progressWithinLevel = getXPWithinLevel(safeXP);
+  const levelPercent = calculateXPProgress(
+    progressWithinLevel,
+    Number.isFinite(requiredXP) ? requiredXP : 1,
+  );
+  const nextLevelIn = getXPToNextLevel(safeXP);
 
   const rank = getRankForLevel(level);
 
@@ -112,7 +116,8 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
       <Flex direction="row" alignItems="center" gap="small" marginBottom="small">
         <Badge variation="info">Level {level}</Badge>
         <Text color={tokens.colors.font.secondary} fontSize="0.9rem">
-          {progressWithinLevel}/{XP_PER_LEVEL} XP this level
+          {progressWithinLevel}/
+          {Number.isFinite(requiredXP) ? requiredXP : '∞'} XP this level
         </Text>
       </Flex>
 

--- a/src/context/ProgressContext.tsx
+++ b/src/context/ProgressContext.tsx
@@ -55,7 +55,6 @@ interface ProviderProps {
   children: ReactNode;
 }
 
-const XP_PER_LEVEL = 100;
 type UserProgressModel = Schema['UserProgress']['type'];
 
 function startOfDay(d: Date) {
@@ -134,7 +133,7 @@ export function ProgressProvider({ userId, children }: ProviderProps) {
     };
   }, [userId]);
 
-  const level = useMemo(() => getLevelFromXP(xp, XP_PER_LEVEL), [xp]);
+  const level = useMemo(() => getLevelFromXP(xp), [xp]);
 
   const awardXP = useCallback(
     (amount: number) => {

--- a/src/utils/xp.ts
+++ b/src/utils/xp.ts
@@ -1,31 +1,44 @@
-export const XP_PER_LEVEL = 100;
+// XP scaling per level. Caps out at level 160.
+export function xpForLevel(level: number): number {
+  if (level >= 160) return Infinity;
+  // Exponential growth with a gentle curve
+  return Math.floor(100 * Math.pow(1.05, level - 1));
+}
 
-export function calculateXPProgress(
-  currentXP: number,
-  maxXP: number = XP_PER_LEVEL,
-): number {
+export function calculateXPProgress(currentXP: number, maxXP: number): number {
   const pct = (currentXP / maxXP) * 100;
   return Math.max(0, Math.min(100, pct));
 }
 
-export function getLevelFromXP(
-  xp: number,
-  xpPerLevel: number = XP_PER_LEVEL,
-): number {
-  return Math.floor(xp / xpPerLevel) + 1;
+export function getLevelFromXP(xp: number): number {
+  let level = 1;
+  let remaining = xp;
+  while (level < 160) {
+    const needed = xpForLevel(level);
+    if (remaining < needed) break;
+    remaining -= needed;
+    level++;
+  }
+  return level;
 }
 
-export function getXPWithinLevel(
-  xp: number,
-  xpPerLevel: number = XP_PER_LEVEL,
-): number {
-  return xp % xpPerLevel;
+export function getXPWithinLevel(xp: number): number {
+  let level = 1;
+  let remaining = xp;
+  while (level < 160) {
+    const needed = xpForLevel(level);
+    if (remaining < needed) break;
+    remaining -= needed;
+    level++;
+  }
+  return remaining;
 }
 
-export function getXPToNextLevel(
-  xp: number,
-  xpPerLevel: number = XP_PER_LEVEL,
-): number {
-  return Math.max(0, xpPerLevel - getXPWithinLevel(xp, xpPerLevel));
+export function getXPToNextLevel(xp: number): number {
+  const level = getLevelFromXP(xp);
+  const needed = xpForLevel(level);
+  if (!Number.isFinite(needed)) return 0;
+  const current = getXPWithinLevel(xp);
+  return Math.max(0, needed - current);
 }
 

--- a/src/utils/xp.ts
+++ b/src/utils/xp.ts
@@ -1,8 +1,10 @@
 // XP scaling per level. Caps out at level 160.
+// Uses a polynomial curve to keep early levels quick while
+// making later levels progressively harder.
 export function xpForLevel(level: number): number {
   if (level >= 160) return Infinity;
-  // Exponential growth with a gentle curve
-  return Math.floor(100 * Math.pow(1.05, level - 1));
+  // base requirement plus quadratic growth
+  return Math.floor(100 + 10 * Math.pow(level, 2));
 }
 
 export function calculateXPProgress(currentXP: number, maxXP: number): number {
@@ -31,7 +33,7 @@ export function getXPWithinLevel(xp: number): number {
     remaining -= needed;
     level++;
   }
-  return remaining;
+  return level >= 160 ? 0 : remaining;
 }
 
 export function getXPToNextLevel(xp: number): number {


### PR DESCRIPTION
## Summary
- introduce `xpForLevel` to scale XP requirements exponentially and cap at level 160
- update XP calculations and ProgressContext to use new scaling
- adjust stat and announcement components to reflect dynamic XP thresholds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: TS errors such as object literal duplicate properties, missing module '../amplify_outputs.json')*


------
https://chatgpt.com/codex/tasks/task_e_689457e54908832e987e7f360a8a24ed