### PR TITLE
feat: responsive campaign gallery

### DIFF
--- a/src/components/CampaignGallery.css
+++ b/src/components/CampaignGallery.css
@@ -1,0 +1,36 @@
+.campaign-gallery {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding: 8px 0;
+  scrollbar-width: thin;
+}
+
+.gallery-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.gallery-nav-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
+@media (max-width: 768px) {
+  .campaign-gallery {
+    flex-direction: column;
+    overflow-x: visible;
+  }
+
+  .gallery-wrapper {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .gallery-nav-button {
+    display: none;
+  }
+}

--- a/src/components/CampaignGallery.tsx
+++ b/src/components/CampaignGallery.tsx
@@ -1,5 +1,7 @@
 // src/components/CampaignGallery.tsx
-import { memo, type CSSProperties, useEffect } from 'react';
+import { memo, type CSSProperties, useEffect, useRef } from 'react';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
+import './CampaignGallery.css';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 import { useActiveCampaign } from '../context/ActiveCampaignContext';
 import { useCampaigns, type UICampaign } from '../hooks/useCampaigns';
@@ -14,16 +16,11 @@ type CampaignCard = UICampaign & {
 };
 
 const containerStyle: CSSProperties = {
-  display: 'flex',
-  gap: 12,
-  overflowX: 'auto',
-  padding: '8px 0',
-  scrollbarWidth: 'thin',
+  width: 'clamp(180px, 80vw, 100%)',
 };
 
 const cardStyle: CSSProperties = {
-  minWidth: 220,
-  maxWidth: 240,
+  width: 'clamp(180px, 40vw, 240px)',
   flex: '0 0 auto',
   borderRadius: 12,
   border: '1px solid #E5E7EB',
@@ -37,7 +34,7 @@ const cardStyle: CSSProperties = {
 
 const thumbStyle: CSSProperties = {
   width: '100%',
-  height: 120,
+  height: 'clamp(100px, 20vw, 160px)',
   objectFit: 'cover',
   background: '#F3F4F6',
 };
@@ -121,6 +118,11 @@ function CampaignGalleryInner() {
   const { campaigns, loading, error, refresh } = useCampaigns(userId);
   const { activeCampaignId, setActiveCampaignId } = useActiveCampaign();
   const { completedCampaigns } = useProgress();
+  const galleryRef = useRef<HTMLDivElement>(null);
+
+  const scrollBy = (offset: number) => {
+    galleryRef.current?.scrollBy({ left: offset, behavior: 'smooth' });
+  };
 
   // Refresh campaigns whenever progress changes (unlocking new ones)
   useEffect(() => {
@@ -146,15 +148,36 @@ function CampaignGalleryInner() {
   if (!campaigns?.length) return <div>No campaigns yet.</div>;
 
   return (
-    <div style={containerStyle}>
-      {campaigns.map((c) => (
-        <CampaignCardView
-          key={c.id}
-          c={c}
-          active={c.id === activeCampaignId}
-          onClick={() => !c.locked && setActiveCampaignId(c.id)}
-        />
-      ))}
+    <div className="gallery-wrapper">
+      <button
+        className="gallery-nav-button"
+        aria-label="Scroll left"
+        onClick={() => scrollBy(-240)}
+      >
+        <FaChevronLeft />
+      </button>
+      <div
+        className="campaign-gallery"
+        style={containerStyle}
+        ref={galleryRef}
+        tabIndex={0}
+      >
+        {campaigns.map((c) => (
+          <CampaignCardView
+            key={c.id}
+            c={c}
+            active={c.id === activeCampaignId}
+            onClick={() => !c.locked && setActiveCampaignId(c.id)}
+          />
+        ))}
+      </div>
+      <button
+        className="gallery-nav-button"
+        aria-label="Scroll right"
+        onClick={() => scrollBy(240)}
+      >
+        <FaChevronRight />
+      </button>
     </div>
   );
 }

--- a/src/components/UserStatsPanel.tsx
+++ b/src/components/UserStatsPanel.tsx
@@ -59,7 +59,7 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
   const containerStyle = {
     position: 'sticky' as const,
     top: headerHeight + spacing,
-    maxWidth: '320px',
+    maxWidth: 'clamp(240px, 50vw, 320px)',
   };
 
   if (profileLoading)


### PR DESCRIPTION
## Summary
- add responsive clamp widths to campaign cards and thumbnails
- stack campaign gallery vertically on narrow screens with CSS media queries
- add keyboard-accessible buttons to scroll the campaign gallery

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68945b89b7f0832e9190ed2180e97f8c