### PR TITLE
refactor: move header styles to css module

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -26,10 +26,20 @@ body {
   text-align: center;
 }
 
+:root {
+  --header-height: 140px;
+}
+
+@media (max-width: 600px) {
+  :root {
+    --header-height: 100px;
+  }
+}
+
 /* If your authenticated app uses a fixed header, this keeps content from
    sliding underneath it. It doesn't affect the unauthenticated screen. */
 main {
-  padding-top: 160px;
+  padding-top: var(--header-height);
 }
 
 /* ============================

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -1,0 +1,114 @@
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0 clamp(1rem, 5vw, 40px);
+  position: fixed;
+  inset: 0 0 auto 0;
+  background-color: #0b1526;
+  color: #fff;
+  z-index: 1000;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  height: var(--header-height);
+  min-height: var(--header-height);
+  --logo-size: clamp(60px, 10vw, 95px);
+  --pill-icon-size: clamp(40px, 8vw, 75px);
+  --title-size: clamp(1.25rem, 4vw, 1.75rem);
+}
+
+.logoTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.logo {
+  width: var(--logo-size);
+  height: var(--logo-size);
+  object-fit: contain;
+  display: block;
+}
+
+.title {
+  font-weight: 800;
+  color: #fff;
+  margin: 0;
+  line-height: 1.1;
+  font-size: var(--title-size);
+  letter-spacing: 0.2px;
+}
+
+.titleHighlight {
+  color: #e7bb73;
+  font-weight: 800;
+}
+
+.pills {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.pill {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 9999px;
+  background-color: #0f172a;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  white-space: nowrap;
+}
+
+.pillIcon {
+  width: var(--pill-icon-size);
+  height: var(--pill-icon-size);
+  object-fit: contain;
+  display: block;
+}
+
+.pillText {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.pillLabel {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--pill-label-color, #ffffff);
+}
+
+.pillSublabel {
+  font-size: 0.72rem;
+  color: var(--pill-sublabel-color, #e0e0e0);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.signOutButton {
+  background-color: #e7bb73;
+  border: none;
+  color: #eef1f3ff;
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .header {
+    padding: 0 1rem;
+  }
+  .pills {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,8 @@
 // src/components/Header.tsx
-import { forwardRef } from 'react';
-import { Button, Flex, Text } from '@aws-amplify/ui-react';
+import { forwardRef, CSSProperties, useEffect } from 'react';
+import { Button, Text } from '@aws-amplify/ui-react';
 import { useProgress } from '../context/ProgressContext';
+import styles from './Header.module.css';
 
 export interface HeaderProps {
   signOut?: () => void;
@@ -27,49 +28,20 @@ function StatPill({
   iconAlt,
   label,
   sublabel,
-  iconSize = 22,
-  labelColor = '#ffffff',
-  sublabelColor = '#e0e0e0',
 }: {
   iconSrc: string;
   iconAlt: string;
   label: string;
   sublabel?: string;
-  iconSize?: number;
-  labelColor?: string;
-  sublabelColor?: string;
 }) {
   return (
-    <Flex
-      alignItems="center"
-      gap="0.5rem"
-      padding="0.45rem 0.75rem"
-      borderRadius="9999px"
-      backgroundColor="#0f172a"
-      color={labelColor}
-      style={{
-        border: '1px solid rgba(255,255,255,0.08)',
-        whiteSpace: 'nowrap',
-      }}
-    >
-      <img
-        src={iconSrc}
-        alt={iconAlt}
-        width={iconSize}
-        height={iconSize}
-        style={{ display: 'block', objectFit: 'contain' }}
-      />
-      <Flex direction="column" lineHeight="1.1">
-        <Text fontSize="0.85rem" fontWeight={700} color={labelColor}>
-          {label}
-        </Text>
-        {sublabel && (
-          <Text fontSize="0.72rem" color={sublabelColor}>
-            {sublabel}
-          </Text>
-        )}
-      </Flex>
-    </Flex>
+    <div className={styles.pill}>
+      <img src={iconSrc} alt={iconAlt} className={styles.pillIcon} />
+      <div className={styles.pillText}>
+        <Text className={styles.pillLabel}>{label}</Text>
+        {sublabel && <Text className={styles.pillSublabel}>{sublabel}</Text>}
+      </div>
+    </div>
   );
 }
 
@@ -92,100 +64,68 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(
     const xpSub = `${xp}/${maxXP} XP`;
     const bountiesCompleted = completedSections.length;
 
+    useEffect(() => {
+      document.documentElement.style.setProperty('--header-height', `${height}px`);
+    }, [height]);
+
     return (
       <header
         ref={ref}
-        className="main-header"
+        className={styles.header}
         style={{
-          height,
-          minHeight: height,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: '1rem',
-          padding: '0 40px', // Increase/decrease this to move logo/sign-out in from edges
-          position: 'fixed',
-          inset: '0 0 auto 0',
-          backgroundColor: '#0b1526',
-          color: '#fff',
-          zIndex: 1000,
-          boxShadow: '0 2px 8px rgba(0,0,0,0.25)',
-        }}
+          '--logo-size': `${logoSize}px`,
+          '--pill-icon-size': `${iconSize}px`,
+          '--title-size': `${titleSizeRem}rem`,
+          '--pill-label-color': pillLabelColor,
+          '--pill-sublabel-color': pillSubLabelColor,
+        } as CSSProperties}
       >
         {/* Left: logo + title */}
-        <Flex alignItems="center" gap="0.75rem">
+        <div className={styles.logoTitle}>
           <img
             src="/raccoon_bounty.png"
             alt="Raccoon Bounty"
-            width={logoSize}
-            height={logoSize}
-            style={{ objectFit: 'contain', display: 'block' }}
+            className={styles.logo}
           />
-          <Text
-            as="h1"
-            fontWeight={800}
-            color="#fff"
-            margin="0"
-            lineHeight="1.1"
-            style={{ fontSize: `${titleSizeRem}rem`, letterSpacing: 0.2 }}
-          >
+          <Text as="h1" className={styles.title}>
             Raccoon Bounty |{' '}
-            <span style={{ color: '#e7bb73', fontWeight: 800 }}>Treasure Hunting Gym</span>
+            <span className={styles.titleHighlight}>Treasure Hunting Gym</span>
           </Text>
-        </Flex>
+        </div>
 
         {/* Center: stat pills */}
-        <Flex
-          alignItems="center"
-          justifyContent="center"
-          gap="0.75rem"
-          style={{ minWidth: 0, flex: '1 1 auto' }}
-        >
+        <div className={styles.pills}>
           <StatPill
             iconSrc="/raccoon.png"
             iconAlt="Experience"
             label={`Level ${level}`}
             sublabel={xpSub}
-            iconSize={iconSize}
-            labelColor={pillLabelColor}
-            sublabelColor={pillSubLabelColor}
           />
           <StatPill
             iconSrc="/totem.png"
             iconAlt="Bounties completed"
             label={`${bountiesCompleted} completed`}
             sublabel="bounties"
-            iconSize={iconSize}
-            labelColor={pillLabelColor}
-            sublabelColor={pillSubLabelColor}
           />
           <StatPill
             iconSrc="/blaze.png"
             iconAlt="Daily streak"
             label={`${streak} day blaze`}
             sublabel="daily streak"
-            iconSize={iconSize}
-            labelColor={pillLabelColor}
-            sublabelColor={pillSubLabelColor}
           />
-        </Flex>
+        </div>
 
         {/* Right: actions */}
-        <Flex alignItems="center" gap="0.75rem">
+        <div className={styles.actions}>
           <Button
             onClick={signOut}
             variation="primary"
             size="small"
-            style={{
-              backgroundColor: '#e7bb73',
-              border: 'none',
-              color: '#eef1f3ff',
-              fontWeight: 600,
-            }}
+            className={styles.signOutButton}
           >
             Sign Out
           </Button>
-        </Flex>
+        </div>
       </header>
     );
   }


### PR DESCRIPTION
## Summary
- refactor header to use a CSS module and responsive CSS variables
- add mobile media rules for stat pills and header spacing
- link main padding to header height variable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68945b8517c0832eacdde52adfb2012c