### PR TITLE
refactor: move authenticated shell grid to css

### DIFF
--- a/src/pages/AuthenticatedShell.css
+++ b/src/pages/AuthenticatedShell.css
@@ -1,0 +1,54 @@
+.authenticated-grid {
+  display: grid;
+  grid-template-areas:
+    "header header header"
+    "banner banner banner"
+    "gallery canvas stats";
+  grid-template-columns: 1fr 2fr 1fr;
+  grid-auto-rows: auto;
+  min-height: 100vh;
+  gap: 24px;
+}
+
+.auth-header {
+  grid-area: header;
+}
+
+.auth-banner {
+  grid-area: banner;
+}
+
+.auth-gallery {
+  grid-area: gallery;
+}
+
+.auth-canvas {
+  grid-area: canvas;
+}
+
+.auth-stats {
+  grid-area: stats;
+}
+
+@media (max-width: 1024px) {
+  .authenticated-grid {
+    grid-template-areas:
+      "header header"
+      "banner banner"
+      "gallery canvas"
+      "stats stats";
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .authenticated-grid {
+    grid-template-areas:
+      "header"
+      "banner"
+      "gallery"
+      "canvas"
+      "stats";
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/AuthenticatedShell.tsx
+++ b/src/pages/AuthenticatedShell.tsx
@@ -1,5 +1,5 @@
 // src/pages/AuthenticatedShell.tsx
-import { useEffect, useRef, useState, useMemo } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 import { fetchUserAttributes } from 'aws-amplify/auth';
 
@@ -16,6 +16,7 @@ import { ProgressProvider } from '../context/ProgressContext';
 import { ActiveCampaignProvider } from '../context/ActiveCampaignContext';
 import { UserProfileProvider } from '../context/UserProfileContext';
 import DisplayNamePrompt from '../components/DisplayNamePrompt';
+import './AuthenticatedShell.css';
 
 export default function AuthenticatedShell() {
   const { user, signOut, authStatus } = useAuthenticator((ctx) => [ctx.user, ctx.authStatus]);
@@ -43,41 +44,29 @@ export default function AuthenticatedShell() {
   const headerHeight = useHeaderHeight(headerRef);
   const spacing = 24;
 
-  const gridStyle = useMemo(
-    () => ({
-      display: 'grid',
-      gridTemplateAreas: `"header header header" "banner banner banner" "gallery canvas stats"`,
-      gridTemplateColumns: '1fr 2fr 1fr',
-      gridAutoRows: 'auto',
-      minHeight: '100vh',
-      gap: spacing,
-    }),
-    [spacing]
-  );
-
   return (
     <UserProfileProvider userId={userId} email={emailFromAttrs}>
       <ActiveCampaignProvider>
         <ProgressProvider userId={userId}>
           <DisplayNamePrompt />
-          <div style={gridStyle}>
-            <div style={{ gridArea: 'header' }}>
+          <div className="authenticated-grid">
+            <div className="auth-header">
               <HeaderBar ref={headerRef} signOut={signOut} />
             </div>
 
-            <div style={{ gridArea: 'banner' }}>
+            <div className="auth-banner">
               <AnnouncementBanner />
             </div>
 
-            <div style={{ gridArea: 'gallery' }}>
+            <div className="auth-gallery">
               <CampaignGallery campaigns={campaigns} loading={campaignsLoading} />
             </div>
 
-            <div style={{ gridArea: 'canvas' }}>
+            <div className="auth-canvas">
               <CampaignCanvas userId={userId} />
             </div>
 
-            <div style={{ gridArea: 'stats' }}>
+            <div className="auth-stats">
               <UserStatsPanelWithProfile
                 username={user?.username}
                 email={emailFromAttrs ?? undefined}


### PR DESCRIPTION
## Summary
- move AuthenticatedShell grid layout to CSS classes
- add responsive grid templates for desktop, tablet, and mobile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68945b7a2624832eac8e4f1119657a48