### PR TITLE
feat: make user stats panel responsive

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -300,6 +300,55 @@ p {
   }
 }
 
+/* ============================
+   Authenticated shell layout
+============================ */
+.app-grid {
+  display: grid;
+  gap: var(--gap);
+  grid-template-areas:
+    "header header header"
+    "banner banner banner"
+    "gallery canvas stats";
+  grid-template-columns: 1fr 2fr 1fr;
+  min-height: 100vh;
+}
+
+.app-grid > .grid-header { grid-area: header; }
+.app-grid > .grid-banner { grid-area: banner; }
+.app-grid > .grid-gallery { grid-area: gallery; }
+.app-grid > .grid-canvas { grid-area: canvas; }
+.app-grid > .grid-stats { grid-area: stats; }
+
+@media (max-width: 1023px) {
+  .app-grid {
+    grid-template-areas:
+      "header"
+      "banner"
+      "gallery"
+      "canvas"
+      "stats";
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ============================
+   User stats panel
+============================ */
+.user-stats-panel {
+  position: sticky;
+  top: var(--top-offset);
+  max-width: 320px;
+}
+
+@media (max-width: 1023px) {
+  .user-stats-panel {
+    position: static;
+    width: 100%;
+    max-width: none;
+  }
+}
+
 
 
 

--- a/src/components/UserStatsPanel.tsx
+++ b/src/components/UserStatsPanel.tsx
@@ -18,6 +18,7 @@ import {
   getXPToNextLevel,
 } from '../utils/xp';
 import XPBar from './XPBar';
+import type { CSSProperties } from 'react';
 
 interface UserStatsPanelProps {
   headerHeight: number;
@@ -56,21 +57,25 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
   const levelPercent = calculateXPProgress(progressWithinLevel, XP_PER_LEVEL);
   const nextLevelIn = getXPToNextLevel(safeXP, XP_PER_LEVEL);
 
-  const containerStyle = {
-    position: 'sticky' as const,
-    top: headerHeight + spacing,
-    maxWidth: '320px',
-  };
+  const topOffset = headerHeight + spacing;
 
   if (profileLoading)
     return (
-      <View padding={spacing} style={containerStyle}>
+      <View
+        padding={spacing}
+        className="user-stats-panel"
+        style={{ '--top-offset': `${topOffset}px` } as CSSProperties}
+      >
         Loading profile…
       </View>
     );
   if (profileError)
     return (
-      <View padding={spacing} style={containerStyle}>
+      <View
+        padding={spacing}
+        className="user-stats-panel"
+        style={{ '--top-offset': `${topOffset}px` } as CSSProperties}
+      >
         Error loading profile: {profileError.message}
       </View>
     );
@@ -78,7 +83,8 @@ export default function UserStatsPanel({ headerHeight, spacing }: UserStatsPanel
   return (
     <View
       padding={spacing}
-      style={containerStyle}
+      className="user-stats-panel"
+      style={{ '--top-offset': `${topOffset}px` } as CSSProperties}
     >
       <Heading level={3} marginBottom="small">
         User Stats

--- a/src/pages/AuthenticatedShell.tsx
+++ b/src/pages/AuthenticatedShell.tsx
@@ -1,5 +1,5 @@
 // src/pages/AuthenticatedShell.tsx
-import { useEffect, useRef, useState, useMemo } from 'react';
+import { useEffect, useRef, useState, CSSProperties } from 'react';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 import { fetchUserAttributes } from 'aws-amplify/auth';
 
@@ -43,41 +43,32 @@ export default function AuthenticatedShell() {
   const headerHeight = useHeaderHeight(headerRef);
   const spacing = 24;
 
-  const gridStyle = useMemo(
-    () => ({
-      display: 'grid',
-      gridTemplateAreas: `"header header header" "banner banner banner" "gallery canvas stats"`,
-      gridTemplateColumns: '1fr 2fr 1fr',
-      gridAutoRows: 'auto',
-      minHeight: '100vh',
-      gap: spacing,
-    }),
-    [spacing]
-  );
-
   return (
     <UserProfileProvider userId={userId} email={emailFromAttrs}>
       <ActiveCampaignProvider>
         <ProgressProvider userId={userId}>
           <DisplayNamePrompt />
-          <div style={gridStyle}>
-            <div style={{ gridArea: 'header' }}>
+          <div
+            className="app-grid"
+            style={{ '--gap': `${spacing}px` } as CSSProperties}
+          >
+            <div className="grid-header">
               <HeaderBar ref={headerRef} signOut={signOut} />
             </div>
 
-            <div style={{ gridArea: 'banner' }}>
+            <div className="grid-banner">
               <AnnouncementBanner />
             </div>
 
-            <div style={{ gridArea: 'gallery' }}>
+            <div className="grid-gallery">
               <CampaignGallery campaigns={campaigns} loading={campaignsLoading} />
             </div>
 
-            <div style={{ gridArea: 'canvas' }}>
+            <div className="grid-canvas">
               <CampaignCanvas userId={userId} />
             </div>
 
-            <div style={{ gridArea: 'stats' }}>
+            <div className="grid-stats">
               <UserStatsPanelWithProfile
                 username={user?.username}
                 email={emailFromAttrs ?? undefined}


### PR DESCRIPTION
## Summary
- convert UserStatsPanel inline container style to a responsive CSS class
- switch AuthenticatedShell layout to CSS grid and reposition stats panel below content on narrow screens
- add responsive rules for UserStatsPanel so it spans full width below 1024px

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68945b8b8e2c832e9dd7b7310e177ebc