### PR TITLE
feat: apply custom Amplify theme

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,10 +4,13 @@ import ReactDOM from 'react-dom/client';
 import { Amplify } from 'aws-amplify';
 import outputs from '../amplify_outputs.json'; // Amplify Gen 2 outputs (project root)
 import App from './App';
+import { ThemeProvider as AmplifyProvider } from '@aws-amplify/ui-react';
+import customTheme from './theme';
 
 // Global styles
 import '@aws-amplify/ui-react/styles.css'; // Amplify UI (Authenticator, etc.)
 import './App.css';
+import './theme.css';
 
 /**
  * Configure Amplify *once* before any Amplify UI components/hooks mount.
@@ -31,7 +34,9 @@ if (!rootEl) {
 
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>
-    <App />
+    <AmplifyProvider theme={customTheme}>
+      <App />
+    </AmplifyProvider>
   </React.StrictMode>
 );
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,20 @@
+:root, [data-amplify-theme] {
+  /* Font tokens */
+  --amplify-fonts-default-variable: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+  --amplify-fonts-default-static: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+
+  /* Color tokens */
+  --amplify-colors-background-primary: #f8f9fa;
+  --amplify-colors-font-primary: #111827;
+  --amplify-colors-brand-primary-10: #e7bb73;
+  --amplify-colors-brand-primary-80: #d8a854;
+
+  /* Button tokens */
+  --amplify-components-button-border-radius: 4px;
+  --amplify-components-button-font-weight: 600;
+  --amplify-components-button-primary-background-color: var(--amplify-colors-brand-primary-10);
+  --amplify-components-button-primary-border-color: var(--amplify-colors-brand-primary-10);
+  --amplify-components-button-primary-color: #ffffff;
+  --amplify-components-button-primary-hover-background-color: var(--amplify-colors-brand-primary-80);
+  --amplify-components-button-primary-hover-border-color: var(--amplify-colors-brand-primary-80);
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,55 @@
+import type { Theme } from '@aws-amplify/ui-react';
+
+/**
+ * Custom Amplify UI theme that mirrors the design tokens defined in `theme.css`.
+ * These tokens control fonts, colors, and button styles for Amplify components
+ * such as the Authenticator.
+ */
+export const customTheme: Theme = {
+  name: 'custom-theme',
+  tokens: {
+    fonts: {
+      default: {
+        variable: {
+          value:
+            "'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif",
+        },
+        static: {
+          value:
+            "'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif",
+        },
+      },
+    },
+    colors: {
+      background: {
+        primary: { value: '#f8f9fa' },
+      },
+      font: {
+        primary: { value: '#111827' },
+      },
+      brand: {
+        primary: {
+          10: { value: '#e7bb73' },
+          80: { value: '#d8a854' },
+        },
+      },
+    },
+    components: {
+      button: {
+        borderRadius: { value: '4px' },
+        fontWeight: { value: '600' },
+        primary: {
+          backgroundColor: { value: '{colors.brand.primary.10}' },
+          borderColor: { value: '{colors.brand.primary.10}' },
+          color: { value: '#ffffff' },
+          _hover: {
+            backgroundColor: { value: '{colors.brand.primary.80}' },
+            borderColor: { value: '{colors.brand.primary.80}' },
+          },
+        },
+      },
+    },
+  },
+};
+
+export default customTheme;


### PR DESCRIPTION
## Summary
- define design tokens in theme.css
- expose matching Amplify Theme object and wrap app with AmplifyProvider

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Cannot find module '../amplify_outputs.json', plus other TS errors)


------
https://chatgpt.com/codex/tasks/task_e_689465271750832e9849c6b270e50cdc