### PR TITLE
Handle missing progress contexts for public campaign viewing

### DIFF
--- a/src/components/CampaignGallery.tsx
+++ b/src/components/CampaignGallery.tsx
@@ -1,12 +1,12 @@
 // src/components/CampaignGallery.tsx
-import { memo, useEffect, useRef } from 'react';
+import { memo, useContext, useEffect, useRef } from 'react';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 import styles from './CampaignGallery.module.css';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 import { useActiveCampaign } from '../context/ActiveCampaignContext';
 import { useCampaigns, type UICampaign } from '../hooks/useCampaigns';
 import { useCampaignThumbnail } from '../hooks/useCampaignThumbnail';
-import { useProgress } from '../context/ProgressContext';
+import ProgressContext from '../context/ProgressContext';
 
 
 // Optional thumbnail props for campaigns
@@ -69,7 +69,8 @@ function CampaignGalleryInner() {
   const userId = user?.userId;
   const { campaigns, loading, error, refresh } = useCampaigns(userId);
   const { activeCampaignId, setActiveCampaignId } = useActiveCampaign();
-  const { completedCampaigns } = useProgress();
+  const progress = useContext(ProgressContext);
+  const completedCampaigns = progress?.completedCampaigns;
   const galleryRef = useRef<HTMLDivElement>(null);
 
   const scrollBy = (offset: number) => {


### PR DESCRIPTION
## Summary
- Guard campaign gallery against absent progress context so public users can browse campaigns
- Safely handle missing progress/user profile in campaign canvas, rendering read-only mode when unauthenticated

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: TS2554/TS2322 errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68946a708ba4832e9554c1bbd0326612