### PR TITLE
refactor: remove redundant mounted ref

### DIFF
--- a/src/hooks/useCampaignQuizData.ts
+++ b/src/hooks/useCampaignQuizData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Question as QuestionUI } from '../types/QuestionTypes';
 import { listSections } from '../services/sectionService';
 import { listQuestions } from '../services/questionService';
@@ -19,14 +19,6 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
   const [sectionTitleByNumber, setSectionTitleByNumber] = useState<Map<number, string>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setErr] = useState<Error | null>(null);
-
-  const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## Summary
- remove mountedRef and its lifecycle effect from useCampaignQuizData
- rely on existing cancelled flag for cleanup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68946af79758832e90b4ac50cefc58a1