### PR TITLE
Add answers to Question type

### DIFF
--- a/src/hooks/useCampaignQuizData.ts
+++ b/src/hooks/useCampaignQuizData.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import type { Question as QuestionUI } from '../types/QuestionTypes';
+import type { Answer, Question as QuestionUI } from '../types/QuestionTypes';
 import { listSections } from '../services/sectionService';
 import { listQuestions } from '../services/questionService';
 
@@ -122,11 +122,13 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
               correctAnswer: row.correctAnswer ?? '',
               hint: row.hint ?? undefined,
               explanation: row.explanation ?? undefined,
-              answers: (row.answers ?? []).map((ans) => ({
-                id: ans.id,
-                content: ans.content,
-                isCorrect: !!ans.isCorrect,
-              })),
+              answers: row.answers
+                ? row.answers.map((ans): Answer => ({
+                    id: ans.id,
+                    content: ans.content,
+                    isCorrect: !!ans.isCorrect,
+                  }))
+                : undefined,
             });
           }
         }

--- a/src/types/QuestionTypes.ts
+++ b/src/types/QuestionTypes.ts
@@ -11,6 +11,13 @@ export interface Question {
   correctAnswer: string;
   hint?: string;
   explanation?: string;
+  answers?: Answer[];
+}
+
+export interface Answer {
+  id: string;
+  content: string;
+  isCorrect: boolean;
 }
 
 export interface SubmitArgs {


### PR DESCRIPTION
## Summary
- expand Question type with optional answers array and supporting Answer interface
- propagate answer data from API in useCampaignQuizData

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: TypeScript compile errors)


------
https://chatgpt.com/codex/tasks/task_e_68946aeae6dc832eb19d0817a85d893b