### PR TITLE
Add SectionAccordion component styles

### DIFF
--- a/src/components/SectionAccordion.module.css
+++ b/src/components/SectionAccordion.module.css
@@ -1,0 +1,27 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: var(--color-bg-dark, #333);
+  color: var(--color-text-inverse, #fff);
+  cursor: pointer;
+}
+
+.arrow {
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid #fff;
+  transition: transform 0.2s ease-in-out;
+}
+
+.expanded .arrow {
+  transform: rotate(180deg);
+}
+
+.locked {
+  opacity: 0.5;
+  pointer-events: none;
+}

--- a/src/components/SectionAccordion.tsx
+++ b/src/components/SectionAccordion.tsx
@@ -1,0 +1,30 @@
+import { useState, type ReactNode } from 'react';
+import styles from './SectionAccordion.module.css';
+
+interface SectionAccordionProps {
+  title: string;
+  children: ReactNode;
+  locked?: boolean;
+}
+
+export default function SectionAccordion({ title, children, locked = false }: SectionAccordionProps) {
+  const [expanded, setExpanded] = useState(false);
+  const headerClasses = [styles.header];
+  if (expanded) headerClasses.push(styles.expanded);
+  if (locked) headerClasses.push(styles.locked);
+
+  return (
+    <section>
+      <button
+        type="button"
+        className={headerClasses.join(' ')}
+        onClick={() => setExpanded((prev) => !prev)}
+        disabled={locked}
+      >
+        <span>{title}</span>
+        <span className={styles.arrow} aria-hidden />
+      </button>
+      {expanded && <div>{children}</div>}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add SectionAccordion styles for header, arrow rotation, and locked state
- create SectionAccordion component that uses these styles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68946fa87370832e83836c319fef8eb3