### PR TITLE
feat: add section accordion for campaign quiz

### DIFF
--- a/src/components/SectionAccordion.module.css
+++ b/src/components/SectionAccordion.module.css
@@ -1,0 +1,51 @@
+.accordion {}
+
+.header {
+  background: var(--color-primary, #3776ff);
+  color: #fff;
+  padding: var(--space-md, 16px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.locked {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.arrow {
+  border: solid #fff;
+  border-width: 0 2px 2px 0;
+  display: inline-block;
+  padding: 3px;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.open {
+  transform: rotate(135deg);
+}
+
+.content {
+  padding: var(--space-md, 16px);
+  border: 1px solid var(--color-primary, #3776ff);
+}
+
+.educationalText {
+  margin: 0 0 var(--space-md, 16px);
+}
+
+.question {
+  margin-bottom: var(--space-md, 16px);
+}
+
+.correct {
+  color: var(--color-success, green);
+}
+
+.feedback {
+  color: var(--color-error, red);
+}
+

--- a/src/components/SectionAccordion.tsx
+++ b/src/components/SectionAccordion.tsx
@@ -1,0 +1,120 @@
+import { useContext, useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import ProgressContext from '../context/ProgressContext';
+import type { Question } from '../types/QuestionTypes';
+import styles from './SectionAccordion.module.css';
+
+interface Props {
+  title: string;
+  educationalText?: string;
+  questions: Question[];
+  locked?: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+  onComplete?: () => void;
+}
+
+export default function SectionAccordion({
+  title,
+  educationalText,
+  questions,
+  locked = false,
+  expanded,
+  onToggle,
+  onComplete,
+}: Props) {
+  const progress = useContext(ProgressContext);
+  const handleAnswer = progress?.handleAnswer;
+  const answeredQuestions = progress?.answeredQuestions ?? [];
+
+  const [responses, setResponses] = useState<Record<string, string>>({});
+  const [correctMap, setCorrectMap] = useState<Record<string, boolean>>(() => {
+    const map: Record<string, boolean> = {};
+    for (const q of questions) {
+      map[q.id] = answeredQuestions.includes(q.id);
+    }
+    return map;
+  });
+  const [feedbackMap, setFeedbackMap] = useState<Record<string, string | null>>({});
+  const [completed, setCompleted] = useState(false);
+
+  useEffect(() => {
+    const allCorrect = questions.every((q) => correctMap[q.id]);
+    if (allCorrect && !completed) {
+      setCompleted(true);
+      onComplete?.();
+    }
+  }, [correctMap, questions, completed, onComplete]);
+
+  const submitFor = (q: Question) => async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const userAnswer = (responses[q.id] ?? '').trim();
+    const isCorrect =
+      userAnswer.toLowerCase() === q.correctAnswer.trim().toLowerCase();
+
+    await handleAnswer?.({
+      questionId: q.id,
+      userAnswer,
+      isCorrect,
+      xp: q.xpValue ?? undefined,
+    });
+
+    if (isCorrect) {
+      setCorrectMap((prev) => ({ ...prev, [q.id]: true }));
+      setFeedbackMap((prev) => ({ ...prev, [q.id]: 'Correct!' }));
+      setTimeout(
+        () => setFeedbackMap((prev) => ({ ...prev, [q.id]: null })),
+        1000,
+      );
+      setResponses((prev) => ({ ...prev, [q.id]: '' }));
+    } else {
+      setFeedbackMap((prev) => ({ ...prev, [q.id]: 'Try again' }));
+    }
+  };
+
+  return (
+    <div className={styles.accordion}>
+      <div
+        className={`${styles.header} ${locked ? styles.locked : ''}`}
+        onClick={!locked ? onToggle : undefined}
+      >
+        <span>{title}</span>
+        <span
+          className={`${styles.arrow} ${expanded ? styles.open : ''}`}
+        ></span>
+      </div>
+      {expanded && !locked && (
+        <div className={styles.content}>
+          {educationalText && (
+            <p className={styles.educationalText}>{educationalText}</p>
+          )}
+          {questions.map((q) => (
+            <div key={q.id} className={styles.question}>
+              <p>{q.text}</p>
+              {correctMap[q.id] ? (
+                <p className={styles.correct}>Correct!</p>
+              ) : (
+                <form onSubmit={submitFor(q)}>
+                  <textarea
+                    value={responses[q.id] ?? ''}
+                    onChange={(e) =>
+                      setResponses((prev) => ({
+                        ...prev,
+                        [q.id]: e.target.value,
+                      }))
+                    }
+                  />
+                  <button type="submit">Submit</button>
+                </form>
+              )}
+              {!correctMap[q.id] && feedbackMap[q.id] && (
+                <p className={styles.feedback}>{feedbackMap[q.id]}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add SectionAccordion component to display quiz sections and track question completion
- replace linear question flow with accordion-based sections in CampaignCanvas
- style accordion headers with toggle arrow and locked state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68946f660b0c832ea381d588fd43bb8f