### PR TITLE
feat: add section completion helper

### DIFF
--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -30,7 +30,7 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
   const markSectionComplete = progress?.markSectionComplete;
   const markCampaignComplete = progress?.markCampaignComplete;
   const answeredQuestions = progress?.answeredQuestions ?? [];
-  const completedSections = progress?.completedSections ?? [];
+  const isSectionComplete = progress?.isSectionComplete;
 
   const userProfile = useContext(UserProfileContext);
   const profile = userProfile?.profile ?? null;
@@ -83,6 +83,15 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
     ? sectionTextByNumber.get(current.section)
     : undefined;
 
+  const isLocked =
+    current.section != null &&
+    current.section > 1 &&
+    !isSectionComplete?.(current.section - 1);
+
+  if (isLocked) {
+    return <div>Section locked. Complete previous sections to continue.</div>;
+  }
+
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (authStatus !== 'authenticated' || !userId) {
@@ -112,12 +121,11 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
       if (allAnswered && current.section != null) {
         const secId = sectionIdByNumber.get(current.section);
         markSectionComplete?.(current.section, secId);
-
-        const completed = new Set(completedSections);
-        completed.add(current.section);
-
         const allSections = new Set(questions.map((q) => q.section));
-        if ([...allSections].every((n) => completed.has(n))) {
+        const allCompleted = [...allSections].every(
+          (n) => n === current.section || isSectionComplete?.(n)
+        );
+        if (allCompleted) {
           markCampaignComplete?.(campaignId);
         }
       }

--- a/src/context/ProgressContext.tsx
+++ b/src/context/ProgressContext.tsx
@@ -41,6 +41,7 @@ interface ProgressContextValue {
   completedCampaigns: string[];
   answeredQuestions: string[];
   title: string;
+  isSectionComplete: (sectionNumber: number) => boolean;
   awardXP: (amount: number) => void;
   markSectionComplete: (section: number, sectionId?: string) => Promise<void>;
   markCampaignComplete: (campaignId: string) => Promise<void>;
@@ -331,6 +332,11 @@ export function ProgressProvider({ userId, children }: ProviderProps) {
     }
   }, [userId, completedCampaigns, emit, awardXP]);
 
+  const isSectionComplete = useCallback(
+    (sectionNumber: number) => completedSections.includes(sectionNumber),
+    [completedSections]
+  );
+
   const value: ProgressContextValue = {
     xp,
     level,
@@ -339,6 +345,7 @@ export function ProgressProvider({ userId, children }: ProviderProps) {
     completedCampaigns,
     answeredQuestions,
     title,
+    isSectionComplete,
     awardXP,
     markSectionComplete,
     markCampaignComplete,


### PR DESCRIPTION
## Summary
- expose `isSectionComplete` helper from ProgressContext
- use helper in CampaignCanvas to gate sections and check campaign completion

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68946fff8720832ea50a269ce5aa0086