### PR TITLE
feat: track question progress per section

### DIFF
--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -6,6 +6,7 @@ import { useActiveCampaign } from '../context/ActiveCampaignContext';
 import ProgressContext from '../context/ProgressContext';
 import UserProfileContext from '../context/UserProfileContext';
 import { listCampaigns } from '../services/campaignService';
+import SectionAccordion from './SectionAccordion';
 
 interface CampaignCanvasProps {
   userId: string;
@@ -137,20 +138,21 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
   return (
     <div data-campaign-id={campaignId ?? ''} data-user-id={userId}>
       {infoText && <p>{infoText}</p>}
-      {sectionTitle && <h3 className="current-section-title">{sectionTitle}</h3>}
-      {sectionText && <p className="current-section-text">{sectionText}</p>}
+      <SectionAccordion title={sectionTitle ?? ''} sectionId={currentSection.id}>
+        {sectionText && <p className="current-section-text">{sectionText}</p>}
 
-      <div className="question-item">
-        <p>{current.text}</p>
-        <form onSubmit={onSubmit}>
-          <textarea
-            value={response}
-            onChange={(e) => setResponse(e.target.value)}
-          />
-          <button type="submit">Submit</button>
-        </form>
-        {feedback && <p className="answer-feedback">{feedback}</p>}
-      </div>
+        <div className="question-item">
+          <p>{current.text}</p>
+          <form onSubmit={onSubmit}>
+            <textarea
+              value={response}
+              onChange={(e) => setResponse(e.target.value)}
+            />
+            <button type="submit">Submit</button>
+          </form>
+          {feedback && <p className="answer-feedback">{feedback}</p>}
+        </div>
+      </SectionAccordion>
     </div>
   );
 }

--- a/src/components/SectionAccordion.tsx
+++ b/src/components/SectionAccordion.tsx
@@ -1,17 +1,45 @@
-import { useState, type ReactNode } from 'react';
+import {
+  useState,
+  type ReactNode,
+  Children,
+  isValidElement,
+  cloneElement,
+} from 'react';
+import type { HandleAnswer, SubmitArgs } from '../types/QuestionTypes';
 import styles from './SectionAccordion.module.css';
 
 interface SectionAccordionProps {
   title: string;
   children: ReactNode;
   locked?: boolean;
+  sectionId?: string;
 }
 
-export default function SectionAccordion({ title, children, locked = false }: SectionAccordionProps) {
+export default function SectionAccordion({
+  title,
+  children,
+  locked = false,
+  sectionId,
+}: SectionAccordionProps) {
   const [expanded, setExpanded] = useState(false);
   const headerClasses = [styles.header];
   if (expanded) headerClasses.push(styles.expanded);
   if (locked) headerClasses.push(styles.locked);
+
+  const enhancedChildren = expanded
+    ? Children.map(children, (child) => {
+        if (!isValidElement(child)) return child;
+        const props = child.props as { handleAnswer?: HandleAnswer };
+        if (props.handleAnswer) {
+          const original = props.handleAnswer;
+          return cloneElement(child, {
+            handleAnswer: (args: SubmitArgs) =>
+              original({ ...args, sectionId }),
+          });
+        }
+        return child;
+      })
+    : null;
 
   return (
     <section>
@@ -24,7 +52,7 @@ export default function SectionAccordion({ title, children, locked = false }: Se
         <span>{title}</span>
         <span className={styles.arrow} aria-hidden />
       </button>
-      {expanded && <div>{children}</div>}
+      {expanded && <div>{enhancedChildren}</div>}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- allow SectionAccordion to carry a sectionId and forward it to handleAnswer calls
- pass section IDs from CampaignCanvas when rendering SectionAccordion

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894745105b8832e842ec11ee4a0e21d