### PR TITLE
feat: allow no section open in campaign canvas

### DIFF
--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -28,15 +28,23 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
   const userProfile = useContext(UserProfileContext);
   const profile = userProfile?.profile ?? null;
 
-  const [sectionIndex, setSectionIndex] = useState(0);
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(0);
   const [questionIndex, setQuestionIndex] = useState(0);
   const [response, setResponse] = useState('');
   const [infoText, setInfoText] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
 
+  const onToggle = (idx: number) => {
+    setExpandedIndex((prev) => {
+      if (prev === idx) return null;
+      if (prev === null || idx <= prev) return idx;
+      return prev;
+    });
+  };
+
   // Reset indices when campaign or sections change
   useEffect(() => {
-    setSectionIndex(0);
+    onToggle(0);
     setQuestionIndex(0);
   }, [campaignId, sections.length]);
 
@@ -69,10 +77,13 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
   const sectionsWithQuestions = sections.filter((s) => s.questions.length > 0);
   if (!sectionsWithQuestions.length)
     return <div>No questions found for this campaign.</div>;
-  if (sectionIndex >= sectionsWithQuestions.length)
+  if (expandedIndex !== null && expandedIndex >= sectionsWithQuestions.length)
     return <div>Campaign complete, {profile?.displayName ?? 'Friend'}!</div>;
 
-  const currentSection = sectionsWithQuestions[sectionIndex];
+  if (expandedIndex === null)
+    return <div>Select a section to begin.</div>;
+
+  const currentSection = sectionsWithQuestions[expandedIndex];
   const current = currentSection.questions[questionIndex];
   const sectionTitle = currentSection.title;
   const sectionText = currentSection.text;
@@ -125,7 +136,7 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
           if (next < currentSection.questions.length) {
             return next;
           }
-          setSectionIndex((s) => s + 1);
+          setExpandedIndex((s) => (s === null ? 0 : s + 1));
           return 0;
         });
       }, 1000);


### PR DESCRIPTION
## Summary
- allow sections on the campaign canvas to be fully collapsed
- add toggle handler for expanding/collapsing sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689474866bec832e831a4f95d3a106a7