### PR TITLE
fix: stabilize public shell and dedupe campaign fetch

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -120,14 +120,16 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(
 
         {/* Right: actions */}
         <div className={styles.actions}>
-          <Button
-            onClick={signOut}
-            variation="primary"
-            size="small"
-            className={styles.signOutButton}
-          >
-            Sign Out
-          </Button>
+          {signOut && (
+            <Button
+              onClick={signOut}
+              variation="primary"
+              size="small"
+              className={styles.signOutButton}
+            >
+              Sign Out
+            </Button>
+          )}
         </div>
       </header>
     );

--- a/src/context/ProgressContext.tsx
+++ b/src/context/ProgressContext.tsx
@@ -349,6 +349,25 @@ export function ProgressProvider({ userId, children }: ProviderProps) {
   return <ProgressContext.Provider value={value}>{children}</ProgressContext.Provider>;
 }
 
+export function GuestProgressProvider({ children }: { children: ReactNode }) {
+  const value: ProgressContextValue = {
+    xp: 0,
+    level: 0,
+    streak: 0,
+    completedSections: [],
+    completedCampaigns: [],
+    answeredQuestions: [],
+    title: '',
+    awardXP: () => {},
+    markSectionComplete: async () => {},
+    markCampaignComplete: async () => {},
+    handleAnswer: async () => {},
+    subscribe: () => () => {},
+  };
+
+  return <ProgressContext.Provider value={value}>{children}</ProgressContext.Provider>;
+}
+
 export function useProgress() {
   const ctx = useContext(ProgressContext);
   if (!ctx) throw new Error('useProgress must be used within ProgressProvider');

--- a/src/pages/AuthenticatedShell.tsx
+++ b/src/pages/AuthenticatedShell.tsx
@@ -9,7 +9,6 @@ import CampaignGallery from '../components/CampaignGallery';
 import CampaignCanvas from '../components/CampaignCanvas';
 import UserStatsPanel from '../components/UserStatsPanel';
 
-import { useCampaigns } from '../hooks/useCampaigns';
 import { useUserProfile } from '../context/UserProfileContext';
 import { useHeaderHeight } from '../hooks/useHeaderHeight';
 import { ProgressProvider } from '../context/ProgressContext';
@@ -38,7 +37,6 @@ export default function AuthenticatedShell() {
   }, [authStatus]);
 
   const emailFromAttrs = attrs?.email ?? null;
-  const { campaigns, loading: campaignsLoading } = useCampaigns(userId);
 
   const headerRef = useRef<HTMLDivElement>(null);
   const headerHeight = useHeaderHeight(headerRef);
@@ -59,7 +57,7 @@ export default function AuthenticatedShell() {
             </div>
 
             <div className="auth-gallery">
-              <CampaignGallery campaigns={campaigns} loading={campaignsLoading} />
+              <CampaignGallery />
             </div>
 
             <div className="auth-canvas">

--- a/src/pages/PublicShell.tsx
+++ b/src/pages/PublicShell.tsx
@@ -1,5 +1,6 @@
 // src/pages/PublicShell.tsx
 import { ActiveCampaignProvider } from '../context/ActiveCampaignContext';
+import { GuestProgressProvider } from '../context/ProgressContext';
 import { Header as HeaderBar } from '../components/Header';
 import AnnouncementBanner from '../components/AnnouncementBanner';
 import CampaignGallery from '../components/CampaignGallery';
@@ -13,20 +14,22 @@ interface PublicShellProps {
 export default function PublicShell({ onRequireAuth }: PublicShellProps) {
   return (
     <ActiveCampaignProvider>
-      <div className={styles.shellGrid}>
-        <div className={styles.headerArea}>
-          <HeaderBar />
+      <GuestProgressProvider>
+        <div className={styles.shellGrid}>
+          <div className={styles.headerArea}>
+            <HeaderBar />
+          </div>
+          <div className={styles.bannerArea}>
+            <AnnouncementBanner />
+          </div>
+          <div className={styles.galleryArea}>
+            <CampaignGallery />
+          </div>
+          <div className={styles.canvasArea}>
+            <CampaignCanvas userId="" onRequireAuth={onRequireAuth} />
+          </div>
         </div>
-        <div className={styles.bannerArea}>
-          <AnnouncementBanner />
-        </div>
-        <div className={styles.galleryArea}>
-          <CampaignGallery />
-        </div>
-        <div className={styles.canvasArea}>
-          <CampaignCanvas userId="" onRequireAuth={onRequireAuth} />
-        </div>
-      </div>
+      </GuestProgressProvider>
     </ActiveCampaignProvider>
   );
 }


### PR DESCRIPTION
## Summary
- provide guest progress context so public shell loads without crashing
- hide sign-out button unless handler supplied
- let campaign gallery handle its own data fetch

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68947a2be82c832ea4b901b1c45bdbd2