### PR TITLE
feat: centralize spacing tokens and improve responsiveness

### DIFF
--- a/src/hooks/useHeaderHeight.ts
+++ b/src/hooks/useHeaderHeight.ts
@@ -13,23 +13,18 @@ export function useHeaderHeight(ref: RefObject<HTMLElement | null>, defaultHeigh
 
     updateHeight();
 
-    const observer = new MutationObserver(updateHeight);
+    const observer = new ResizeObserver(updateHeight);
     if (ref.current) {
-      observer.observe(ref.current, { childList: true, subtree: true, attributes: true });
+      observer.observe(ref.current);
     }
 
     window.addEventListener('resize', updateHeight);
     window.addEventListener('load', updateHeight);
 
-    const interval = setInterval(updateHeight, 200);
-    const timeout = setTimeout(() => clearInterval(interval), 2000);
-
     return () => {
       observer.disconnect();
       window.removeEventListener('resize', updateHeight);
       window.removeEventListener('load', updateHeight);
-      clearInterval(interval);
-      clearTimeout(timeout);
     };
   }, [ref]);
 

--- a/src/pages/PublicShell.module.css
+++ b/src/pages/PublicShell.module.css
@@ -25,3 +25,24 @@
 .canvasArea {
   grid-area: canvas;
 }
+
+@media (max-width: 1024px) {
+  .shellGrid {
+    grid-template-areas:
+      "header header"
+      "banner banner"
+      "gallery canvas";
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .shellGrid {
+    grid-template-areas:
+      "header"
+      "banner"
+      "gallery"
+      "canvas";
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -3,6 +3,13 @@
   --font-sans: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
 
+  /* Spacing scale */
+  --space-xxs: 4px;
+  --space-xs: 8px;
+  --space-sm: 12px;
+  --space-md: 16px;
+  --space-lg: 24px;
+
   /* Text colors */
   --color-text: #111827;
   --color-text-inverse: #ffffff;

--- a/src/theme.css
+++ b/src/theme.css
@@ -3,6 +3,13 @@
   --amplify-fonts-default-variable: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
   --amplify-fonts-default-static: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
 
+  /* Space tokens */
+  --amplify-space-xxs: 4px;
+  --amplify-space-xs: 8px;
+  --amplify-space-sm: 12px;
+  --amplify-space-md: 16px;
+  --amplify-space-lg: 24px;
+
   /* Color tokens */
   --amplify-colors-background-primary: #f8f9fa;
   --amplify-colors-font-primary: #111827;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -34,6 +34,13 @@ export const customTheme: Theme = {
         },
       },
     },
+    space: {
+      xxs: { value: '4px' },
+      xs: { value: '8px' },
+      sm: { value: '12px' },
+      md: { value: '16px' },
+      lg: { value: '24px' },
+    },
     components: {
       button: {
         borderRadius: { value: '4px' },


### PR DESCRIPTION
## Summary
- define shared spacing design tokens for CSS modules and Amplify theme
- switch header height hook to ResizeObserver for smoother updates
- add responsive breakpoints to public shell layout

## Testing
- `npm run lint` *(fails: Unexpected any in ProgressContext, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_6894e0fce064832e944772c2f578596f