### PR TITLE
refactor: add strong types for campaign list selection

### DIFF
--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -1,29 +1,37 @@
 import { ServiceError } from './serviceError';
 import { client } from './client';
 
+type CampaignListOptions = Parameters<typeof client.models.Campaign.list>[0];
+type CampaignSelectionSet = NonNullable<CampaignListOptions['selectionSet']>;
+
+function withInfoTextSelection(
+  options: CampaignListOptions,
+): CampaignListOptions {
+  const baseSelection = (options.selectionSet ?? []) as CampaignSelectionSet;
+  const selection = Array.from(
+    new Set([...baseSelection, 'infoText']),
+  ) as CampaignSelectionSet;
+
+  return {
+    ...options,
+    selectionSet: selection,
+  };
+}
+
 export async function listCampaigns(
-  options: Parameters<typeof client.models.Campaign.list>[0] = {}
+  options: CampaignListOptions = {},
 ) {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const baseSelection = (options as any).selectionSet ?? [];
-    const selection = Array.from(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      new Set([...(baseSelection as any[]), 'infoText'])
+    return await client.models.Campaign.list(
+      withInfoTextSelection(options),
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return await (client.models.Campaign.list as any)({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ...(options as any),
-      selectionSet: selection,
-    });
   } catch (err) {
     throw new ServiceError('Failed to list campaigns', { cause: err });
   }
 }
 
 export async function createCampaign(
-  input: Parameters<typeof client.models.Campaign.create>[0]
+  input: Parameters<typeof client.models.Campaign.create>[0],
 ) {
   try {
     return await client.models.Campaign.create(input);
@@ -33,7 +41,7 @@ export async function createCampaign(
 }
 
 export async function updateCampaign(
-  input: Parameters<typeof client.models.Campaign.update>[0]
+  input: Parameters<typeof client.models.Campaign.update>[0],
 ) {
   try {
     return await client.models.Campaign.update(input);


### PR DESCRIPTION
## Summary
- remove any casts in `listCampaigns`
- type helper to merge `infoText` into selection set

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894f2588e8c832e9ebce3940cc4a36d