### PR TITLE
Fix build errors and update context logic

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 import { forwardRef, useEffect, useRef, useState } from 'react';
 import { Button, Text } from '@aws-amplify/ui-react';
 import { useProgress } from '../context/ProgressContext';
+import { xpForLevel, getXPWithinLevel } from '../utils/xp';
 import styles from './Header.module.css';
 
 export interface HeaderProps {
@@ -62,8 +63,9 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(
   ) => {
     // Daily streak now comes directly from ProgressContext (updated via awardXP)
     const { xp, level, streak, completedSections } = useProgress();
-    const maxXP = level * 100;
-    const xpSub = `${xp}/${maxXP} XP`;
+    const maxXP = xpForLevel(level);
+    const xpWithin = getXPWithinLevel(xp);
+    const xpSub = `${xpWithin}/${maxXP} XP`;
     const bountiesCompleted = completedSections.length;
 
     const [levelAnim, setLevelAnim] = useState(false);

--- a/src/components/SectionAccordion.tsx
+++ b/src/components/SectionAccordion.tsx
@@ -36,10 +36,13 @@ export default function SectionAccordion({
         const props = child.props as { handleAnswer?: HandleAnswer };
         if (props.handleAnswer) {
           const original = props.handleAnswer;
-          return cloneElement(child, {
-            handleAnswer: (args: SubmitArgs) =>
-              original({ ...args, sectionId }),
-          });
+          return cloneElement(
+            child as React.ReactElement<{ handleAnswer?: HandleAnswer }>,
+            {
+              handleAnswer: (args: SubmitArgs) =>
+                original({ ...args, sectionId }),
+            },
+          );
         }
         return child;
       })

--- a/src/context/ProgressContext.tsx
+++ b/src/context/ProgressContext.tsx
@@ -55,7 +55,6 @@ interface ProviderProps {
   children: ReactNode;
 }
 
-const XP_PER_LEVEL = 100;
 const XP_FOR_SECTION = 50;
 const XP_FOR_CAMPAIGN = 200;
 
@@ -261,8 +260,8 @@ export function ProgressProvider({ userId, children }: ProviderProps) {
               }
 
               // Emit events to update UI
-              const prevLevel = getLevelFromXP(prevXP, XP_PER_LEVEL);
-              const newLevel = getLevelFromXP(mergedXP, XP_PER_LEVEL);
+              const prevLevel = getLevelFromXP(prevXP);
+              const newLevel = getLevelFromXP(mergedXP);
               if (newLevel > prevLevel) emit({ type: 'level', level: newLevel, xp: guestXP });
 
               const newSections = guestSections.filter((s) => !(row.completedSections ?? []).includes(s));
@@ -311,7 +310,7 @@ export function ProgressProvider({ userId, children }: ProviderProps) {
     };
   }, []);
 
-  const level = useMemo(() => getLevelFromXP(xp, XP_PER_LEVEL), [xp]);
+  const level = useMemo(() => getLevelFromXP(xp), [xp]);
   const title = useMemo(() => {
     if (!titles.length) return '';
     let current: Schema['Title']['type'] | null = null;
@@ -343,8 +342,8 @@ export function ProgressProvider({ userId, children }: ProviderProps) {
 
     setXP((prev) => {
       const newXP = prev + amount;
-      const prevLevel = getLevelFromXP(prev, XP_PER_LEVEL);
-      const newLevel = getLevelFromXP(newXP, XP_PER_LEVEL);
+      const prevLevel = getLevelFromXP(prev);
+      const newLevel = getLevelFromXP(newXP);
       if (newLevel > prevLevel) emit({ type: 'level', level: newLevel, xp: amount });
       if (progressId) {
         updateUserProgress({
@@ -607,8 +606,8 @@ export function GuestProgressProvider({ children }: { children: ReactNode }) {
 
       setXP((prev) => {
         const newXP = prev + amount;
-        const prevLevel = getLevelFromXP(prev, XP_PER_LEVEL);
-        const newLevel = getLevelFromXP(newXP, XP_PER_LEVEL);
+        const prevLevel = getLevelFromXP(prev);
+        const newLevel = getLevelFromXP(newXP);
         if (newLevel > prevLevel) emit({ type: 'level', level: newLevel, xp: amount });
         return newXP;
       });
@@ -655,7 +654,7 @@ export function GuestProgressProvider({ children }: { children: ReactNode }) {
     [awardXP]
   );
 
-  const level = useMemo(() => getLevelFromXP(xp, XP_PER_LEVEL), [xp]);
+  const level = useMemo(() => getLevelFromXP(xp), [xp]);
   const title = useMemo(() => {
     if (!titles.length) return '';
     let current: Schema['Title']['type'] | null = null;

--- a/src/pages/AuthenticatedShell.tsx
+++ b/src/pages/AuthenticatedShell.tsx
@@ -11,7 +11,6 @@ import Skeleton from '../components/Skeleton';
 const CampaignGallery = lazy(() => import('../components/CampaignGallery'));
 const CampaignCanvas = lazy(() => import('../components/CampaignCanvas'));
 
-import { useUserProfile } from '../context/UserProfileContext';
 import { useHeaderHeight } from '../hooks/useHeaderHeight';
 import { ProgressProvider } from '../context/ProgressContext';
 import { ActiveCampaignProvider } from '../context/ActiveCampaignContext';
@@ -71,46 +70,12 @@ export default function AuthenticatedShell() {
             </div>
 
             <div className="auth-stats">
-              <UserStatsPanelWithProfile
-                username={user?.username}
-                email={emailFromAttrs ?? undefined}
-                headerHeight={headerHeight}
-                spacing={spacing}
-              />
+              <UserStatsPanel headerHeight={headerHeight} spacing={spacing} />
             </div>
           </div>
         </ProgressProvider>
       </ActiveCampaignProvider>
     </UserProfileProvider>
-  );
-}
-
-// Helper component to use profile inside stats panel
-function UserStatsPanelWithProfile({
-  username,
-  email,
-  headerHeight,
-  spacing,
-}: {
-  username?: string;
-  email?: string;
-  headerHeight: number;
-  spacing: number;
-}) {
-  const { profile } = useUserProfile();
-
-  return (
-    <UserStatsPanel
-      user={{
-        username,
-        attributes: {
-          name: profile?.displayName ?? '',
-          email,
-        },
-      }}
-      headerHeight={headerHeight}
-      spacing={spacing}
-    />
   );
 }
 

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -1,21 +1,21 @@
 import { ServiceError } from './serviceError';
 import { client } from './client';
 
-type CampaignListOptions = Parameters<typeof client.models.Campaign.list>[0];
-type CampaignSelectionSet = NonNullable<CampaignListOptions['selectionSet']>;
+type CampaignListOptions = Parameters<typeof client.models.Campaign.list>[0] & {
+  selectionSet?: string[];
+};
+type CampaignSelectionSet = string[];
 
 function withInfoTextSelection(
-  options: CampaignListOptions,
+  options: CampaignListOptions = {},
 ): CampaignListOptions {
   const baseSelection = (options.selectionSet ?? []) as CampaignSelectionSet;
-  const selection = Array.from(
-    new Set([...baseSelection, 'infoText']),
-  ) as CampaignSelectionSet;
+  const selection = Array.from(new Set([...baseSelection, 'infoText'])) as CampaignSelectionSet;
 
   return {
     ...options,
     selectionSet: selection,
-  };
+  } as CampaignListOptions;
 }
 
 export async function listCampaigns(

--- a/src/types/amplify-outputs.d.ts
+++ b/src/types/amplify-outputs.d.ts
@@ -1,0 +1,5 @@
+declare module '../amplify_outputs.json' {
+  const outputs: Record<string, unknown>;
+  export default outputs;
+}
+

--- a/src/types/canvas-confetti.d.ts
+++ b/src/types/canvas-confetti.d.ts
@@ -1,0 +1,10 @@
+declare module 'https://cdn.skypack.dev/canvas-confetti' {
+  interface ConfettiOptions {
+    particleCount: number;
+    spread: number;
+    origin: { y: number };
+  }
+  const confetti: (options: ConfettiOptions) => void;
+  export default confetti;
+}
+

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -13,7 +13,7 @@
     "types": ["node"],
     "verbatimModuleSyntax": true
   },
-  "include": ["vite.config.ts", "scripts/**/*.ts"]
+  "include": ["vite.config.ts", "scripts/**/*.ts", "amplify/**/*.ts"]
 }
 
 


### PR DESCRIPTION
## Summary
- calculate XP progress using xp utilities and add module declarations for confetti and Amplify outputs
- remove outdated XP per level parameter in progress context
- clean up props and types for accordion, stats panel, and campaign service
- include Amplify schema files in Node TS config

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npx tsc -b`
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_6894f90adcd4832e8f35be1b8369b041