### PR TITLE
feat: tiered leveling and automatic campaign seeding

### DIFF
--- a/src/context/ProgressContext.tsx
+++ b/src/context/ProgressContext.tsx
@@ -55,8 +55,8 @@ interface ProviderProps {
   children: ReactNode;
 }
 
-const XP_FOR_SECTION = 50;
-const XP_FOR_CAMPAIGN = 200;
+const XP_FOR_SECTION = 40;
+const XP_FOR_CAMPAIGN = 150;
 
 type UserProgressModel = Schema['UserProgress']['type'];
 

--- a/src/utils/seedData.ts
+++ b/src/utils/seedData.ts
@@ -1,0 +1,109 @@
+import {
+  listCampaigns,
+  createCampaign,
+} from '../services/campaignService';
+import { listSections, createSection } from '../services/sectionService';
+import { listQuestions, createQuestion } from '../services/questionService';
+
+// Deterministically generate campaign/section/question structure so that
+// development environments can auto-populate placeholder content.
+
+const TOTAL_CAMPAIGNS = 65;
+
+let seeding: Promise<void> | null = null;
+
+export async function ensureSeedData() {
+  if (!seeding) seeding = seedAll();
+  return seeding;
+}
+
+function sectionsForCampaign(index: number): number {
+  if (index <= 20) return 3;
+  if (index <= 40) return 4;
+  if (index <= 55) return 5;
+  return 6;
+}
+
+function questionsForSection(cIdx: number, sIdx: number): number {
+  if (cIdx <= 20) return 2 + (sIdx % 2); // 2-3
+  if (cIdx <= 40) return 3 + (sIdx % 2); // 3-4
+  if (cIdx <= 55) return 4; // constant 4
+  return 4 + (sIdx % 2); // 4-5
+}
+
+async function seedAll() {
+  try {
+    const existing = await listCampaigns({ selectionSet: ['id'] });
+    const have = new Set((existing.data ?? []).map((c) => c.id));
+
+    for (let i = 1; i <= TOTAL_CAMPAIGNS; i++) {
+      const campaignId = `campaign-${i}`;
+      if (!have.has(campaignId)) {
+        await createCampaign({
+          id: campaignId,
+          title: `Campaign ${i}`,
+          description: `Placeholder description for Campaign ${i}`,
+          infoText: `Placeholder info for Campaign ${i}`,
+          order: i,
+          isActive: true,
+        });
+      }
+      await ensureSectionsAndQuestions(campaignId, i);
+    }
+  } catch (err) {
+    console.error('Failed to seed data', err);
+  }
+}
+
+async function ensureSectionsAndQuestions(campaignId: string, cIndex: number) {
+  const neededSections = sectionsForCampaign(cIndex);
+  const sRes = await listSections({
+    filter: { campaignId: { eq: campaignId } },
+    selectionSet: ['id', 'number'],
+  });
+  const existing = new Map<number, string>();
+  for (const row of sRes.data ?? []) {
+    const num = row.number ?? 0;
+    existing.set(num, row.id);
+  }
+
+  for (let s = 1; s <= neededSections; s++) {
+    let sectionId = existing.get(s);
+    if (!sectionId) {
+      sectionId = `${campaignId}-section-${s}`;
+      await createSection({
+        id: sectionId,
+        campaignId,
+        number: s,
+        order: s,
+        title: `Section ${cIndex}.${s}`,
+        educationalText: `Placeholder text for Section ${cIndex}.${s}`,
+        isActive: true,
+      });
+    }
+    await ensureQuestions(sectionId, cIndex, s);
+  }
+}
+
+async function ensureQuestions(sectionId: string, cIndex: number, sIndex: number) {
+  const needed = questionsForSection(cIndex, sIndex);
+  const qRes = await listQuestions({
+    filter: { sectionId: { eq: sectionId } },
+    selectionSet: ['id'],
+  });
+  const existing = new Set((qRes.data ?? []).map((q) => q.id));
+
+  for (let q = 1; q <= needed; q++) {
+    const questionId = `${sectionId}-question-${q}`;
+    if (existing.has(questionId)) continue;
+    await createQuestion({
+      id: questionId,
+      sectionId,
+      text: `Question ${cIndex}.${sIndex}.${q}?`,
+      correctAnswer: 'Placeholder',
+      order: q,
+      xpValue: 10,
+    });
+  }
+}
+

--- a/src/utils/xp.ts
+++ b/src/utils/xp.ts
@@ -1,10 +1,13 @@
-// XP scaling per level. Caps out at level 160.
-// Uses a polynomial curve to keep early levels quick while
-// making later levels progressively harder.
+// XP required to advance from the given level to the next.
+// Uses a tiered curve so early levels feel quick and later levels
+// require more effort. Caps out at level 160.
 export function xpForLevel(level: number): number {
   if (level >= 160) return Infinity;
-  // base requirement plus quadratic growth
-  return Math.floor(100 + 10 * Math.pow(level, 2));
+
+  if (level <= 40) return 125;
+  if (level <= 80) return 175;
+  if (level <= 120) return 225;
+  return 265; // levels 121-159
 }
 
 export function calculateXPProgress(currentXP: number, maxXP: number): number {


### PR DESCRIPTION
## Summary
- implement multi-stage XP curve across 160 levels
- award 40 XP per section and 150 XP per campaign
- auto-generate 65 placeholder campaigns with sections and questions for dev use

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894ff6113d0832e9612023cfbcda93d