### PR TITLE
feat: add markdown support for section content

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -38,6 +38,8 @@ const schema = a.schema({
 
       title: a.string(),
       educationalText: a.string(),
+      // New Markdown-based field for richer content
+      educationalRichText: a.string(),
       order: a.integer().default(0),
       isActive: a.boolean().default(true),
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "dependencies": {
     "@aws-amplify/ui-react": "^6.11.2",
     "aws-amplify": "^6.15.5",
+    "react-markdown": "^9.0.0",
+    "remark-gfm": "^4.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0"

--- a/src/App.css
+++ b/src/App.css
@@ -321,6 +321,19 @@ main {
   font-style: italic;
 }
 
+.markdown img {
+  max-width: 100%;
+  height: auto;
+}
+
+.markdown .align-center {
+  text-align: center;
+}
+
+.markdown .align-right {
+  text-align: right;
+}
+
 /* ============================
    Modal (SetDisplayNameModal)
 ============================ */

--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -1,6 +1,10 @@
 import { useContext, useEffect, useMemo, useState } from 'react';
 import type { ChangeEvent, FormEvent } from 'react';
 import { useAuthenticator } from '@aws-amplify/ui-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import { useCampaignQuizData } from '../hooks/useCampaignQuizData';
 import { useActiveCampaign } from '../context/ActiveCampaignContext';
 import UserProfileContext from '../context/UserProfileContext';
@@ -8,6 +12,14 @@ import { listCampaigns } from '../services/campaignService';
 import SectionAccordion from './SectionAccordion';
 import { fallbackCampaigns } from '../utils/fallbackContent';
 import Skeleton from './Skeleton';
+
+const markdownSanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'className', 'style'],
+  },
+};
 
 interface CampaignCanvasProps {
   userId: string;
@@ -205,7 +217,15 @@ export default function CampaignCanvas({ userId, onRequireAuth }: CampaignCanvas
         sectionId={currentSection.id}
         completed={completedSections.includes(currentSection.number)}
       >
-        {sectionText && <p className="current-section-text">{sectionText}</p>}
+        {sectionText && (
+          <ReactMarkdown
+            className="current-section-text markdown"
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeRaw, [rehypeSanitize, markdownSanitizeSchema]]}
+          >
+            {sectionText}
+          </ReactMarkdown>
+        )}
 
         <div className="question-item">
           <p>{current.text}</p>

--- a/src/hooks/useCampaignQuizData.ts
+++ b/src/hooks/useCampaignQuizData.ts
@@ -43,7 +43,15 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
 
         const sRes = await listSections({
           filter: { campaignId: { eq: campaignId } },
-          selectionSet: ['id', 'number', 'order', 'educationalText', 'title', 'isActive'],
+          selectionSet: [
+            'id',
+            'number',
+            'order',
+            'educationalText',
+            'educationalRichText',
+            'title',
+            'isActive',
+          ],
         });
 
         const rawSections = (sRes.data ?? [])
@@ -75,7 +83,7 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
             number: n,
             id: s.id,
             title: s.title ?? '',
-            text: s.educationalText ?? '',
+            text: s.educationalRichText ?? s.educationalText ?? '',
             questions: [],
           };
           sectionObjs.push(section);

--- a/src/services/markdownImageService.ts
+++ b/src/services/markdownImageService.ts
@@ -1,0 +1,25 @@
+import { uploadData, getUrl } from 'aws-amplify/storage';
+import { ServiceError } from './serviceError';
+
+export async function uploadMarkdownImage(key: string, file: File | Blob) {
+  try {
+    await uploadData({
+      key,
+      data: file,
+      options: { contentType: (file as File).type },
+    }).result;
+    const { url } = await getUrl({ key });
+    return url.toString();
+  } catch (err) {
+    throw new ServiceError('Failed to upload image', { cause: err });
+  }
+}
+
+export async function getMarkdownImageUrl(key: string) {
+  try {
+    const { url } = await getUrl({ key });
+    return url.toString();
+  } catch (err) {
+    throw new ServiceError('Failed to get image URL', { cause: err });
+  }
+}

--- a/src/types/QuestionTypes.ts
+++ b/src/types/QuestionTypes.ts
@@ -8,6 +8,7 @@ export interface Question {
   section: number;
   xpValue?: number | null;
   educationalText?: string;
+  educationalRichText?: string;
   correctAnswer: string;
   hint?: string;
   explanation?: string;

--- a/src/utils/seedData.ts
+++ b/src/utils/seedData.ts
@@ -79,6 +79,7 @@ async function ensureSectionsAndQuestions(campaignId: string, cIndex: number) {
         order: s,
         title: `Section ${cIndex}.${s}`,
         educationalText: `Placeholder text for Section ${cIndex}.${s}`,
+        educationalRichText: `**Placeholder** text for Section ${cIndex}.${s}`,
         isActive: true,
       });
     }


### PR DESCRIPTION
## Summary
- add `educationalRichText` field to Section schema for Markdown content
- render section educational content with `react-markdown`, supporting images and alignment
- include helper service for uploading and retrieving images for Markdown

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68950902966c832e97a83ceb61c52e68