### PR TITLE
chore: remove unused quiz section export

### DIFF
--- a/src/hooks/useCampaignQuizData.ts
+++ b/src/hooks/useCampaignQuizData.ts
@@ -6,7 +6,7 @@ import { ensureSeedData } from '../utils/seedData';
 import ProgressContext from '../context/ProgressContext';
 import type { Progress } from '../types/ProgressTypes';
 
-export interface QuizSection {
+interface QuizSection {
   number: number;
   id: string;
   title: string;


### PR DESCRIPTION
## Summary
- make QuizSection interface internal to hook since no other modules import it

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68950a8e1648832eb6d55802542e22f1