### PR TITLE
fix: resolve campaign canvas imports and types

### DIFF
--- a/src/components/QuizSection.tsx
+++ b/src/components/QuizSection.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import type { Question, HandleAnswer } from '../types/QuestionTypes';
+import type { Progress } from '../types/ProgressTypes';
+
+interface Props {
+  title: string;
+  educationalText: string;
+  questions: Question[];
+  progress: Progress;
+  handleAnswer?: HandleAnswer;
+  isLocked?: boolean;
+  initialOpen?: boolean;
+}
+
+export default function QuizSection({
+  title,
+  educationalText,
+  questions,
+  progress,
+  handleAnswer,
+  isLocked = false,
+  initialOpen = false,
+}: Props) {
+  const [open, setOpen] = useState(initialOpen);
+  const completed = progress.completedSections.includes(questions[0]?.section ?? -1);
+
+  return (
+    <section style={{ marginBottom: 16 }}>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        disabled={isLocked}
+        style={{ fontWeight: 'bold' }}
+      >
+        {title}
+        {completed ? ' ✅' : ''}
+      </button>
+      {open && (
+        <div>
+          <p>{educationalText}</p>
+          <ul>
+            {questions.map((q) => (
+              <li key={q.id}>
+                {q.text}
+                {handleAnswer && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      handleAnswer({
+                        questionId: q.id,
+                        userAnswer: '',
+                        isCorrect: false,
+                        sectionId: undefined,
+                      })
+                    }
+                  >
+                    Answer
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/types/ProgressTypes.ts
+++ b/src/types/ProgressTypes.ts
@@ -24,3 +24,20 @@ export interface Progress {
   handleAnswer: HandleAnswer;
   subscribe: (listener: ProgressEventListener) => () => void;
 }
+
+export function createEmptyProgress(): Progress {
+  return {
+    xp: 0,
+    level: 0,
+    streak: 0,
+    completedSections: [],
+    completedCampaigns: [],
+    answeredQuestions: [],
+    title: '',
+    awardXP: () => {},
+    markSectionComplete: async () => {},
+    markCampaignComplete: async () => {},
+    handleAnswer: async () => {},
+    subscribe: () => () => {},
+  };
+}


### PR DESCRIPTION
## Summary
- add `QuizSection` component used by CampaignCanvas
- implement `createEmptyProgress` and clean up CampaignCanvas imports
- wire CampaignCanvas to existing hooks and progress utilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68950e131a0c832e8de958a760ea7336