### PR TITLE
chore: configure seeding scripts and improve campaign logging

### DIFF
--- a/scripts/seedOrders.ts
+++ b/scripts/seedOrders.ts
@@ -1,10 +1,19 @@
+import { Amplify } from 'aws-amplify';
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../amplify/data/resource';
+import outputs from '../amplify_outputs.json';
 
+// Configure Amplify and default to IAM auth so this script can run with
+// locally configured AWS credentials.
+Amplify.configure(outputs);
 const client = generateClient<Schema>();
+const auth = { authMode: 'iam' as const };
 
 async function seedOrders() {
-  const campaigns = await client.models.Campaign.list({ selectionSet: ['id'] });
+  const campaigns = await client.models.Campaign.list({
+    selectionSet: ['id'],
+    ...auth,
+  });
   for (const campaign of campaigns.data ?? []) {
     const campaignId = campaign.id;
     console.log(`Processing campaign ${campaignId}`);
@@ -12,6 +21,7 @@ async function seedOrders() {
     const sectionRes = await client.models.Section.list({
       filter: { campaignId: { eq: campaignId } },
       selectionSet: ['id', 'number'],
+      ...auth,
     });
 
     const sections = (sectionRes.data ?? []).sort(
@@ -20,11 +30,12 @@ async function seedOrders() {
 
     let sectionOrder = 1;
     for (const s of sections) {
-      await client.models.Section.update({ id: s.id, order: sectionOrder });
+      await client.models.Section.update({ id: s.id, order: sectionOrder }, auth);
 
       const questionRes = await client.models.Question.list({
         filter: { sectionId: { eq: s.id } },
         selectionSet: ['id', 'order'],
+        ...auth,
       });
 
       const questions = (questionRes.data ?? []).sort(
@@ -33,7 +44,7 @@ async function seedOrders() {
 
       let qOrder = 1;
       for (const q of questions) {
-        await client.models.Question.update({ id: q.id, order: qOrder });
+        await client.models.Question.update({ id: q.id, order: qOrder }, auth);
         qOrder += 1;
       }
 

--- a/src/hooks/useCampaigns.ts
+++ b/src/hooks/useCampaigns.ts
@@ -83,6 +83,7 @@ export function useCampaigns(userId?: string | null) {
 
       setCampaigns(ui);
     } catch (e) {
+      console.error('Error loading campaigns', e);
       setErr(e as Error);
     } finally {
       setLoading(false);
@@ -120,6 +121,7 @@ export function useCampaigns(userId?: string | null) {
 
       await load(); // refresh gallery lock state
     } catch (e) {
+      console.error('Error marking campaign completed', e);
       setErr(e as Error);
     }
   }, [userId, load]);

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -26,6 +26,7 @@ export async function listCampaigns(
       withInfoTextSelection(options),
     );
   } catch (err) {
+    console.error('listCampaigns failed', err);
     throw new ServiceError('Failed to list campaigns', { cause: err });
   }
 }
@@ -36,6 +37,7 @@ export async function createCampaign(
   try {
     return await client.models.Campaign.create(input);
   } catch (err) {
+    console.error('createCampaign failed', err);
     throw new ServiceError('Failed to create campaign', { cause: err });
   }
 }
@@ -46,6 +48,7 @@ export async function updateCampaign(
   try {
     return await client.models.Campaign.update(input);
   } catch (err) {
+    console.error('updateCampaign failed', err);
     throw new ServiceError('Failed to update campaign', { cause: err });
   }
 }

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -7,6 +7,7 @@ export async function listSections(
   try {
     return await client.models.Section.list(options);
   } catch (err) {
+    console.error('listSections failed', err);
     throw new ServiceError('Failed to list sections', { cause: err });
   }
 }
@@ -17,6 +18,7 @@ export async function createSection(
   try {
     return await client.models.Section.create(input);
   } catch (err) {
+    console.error('createSection failed', err);
     throw new ServiceError('Failed to create section', { cause: err });
   }
 }
@@ -27,6 +29,7 @@ export async function updateSection(
   try {
     return await client.models.Section.update(input);
   } catch (err) {
+    console.error('updateSection failed', err);
     throw new ServiceError('Failed to update section', { cause: err });
   }
 }


### PR DESCRIPTION
## Summary
- configure seed scripts with Amplify outputs and IAM auth
- log backend errors when listing or mutating campaigns/sections
- add error logging in campaign hook

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68952bbdfdf8832e8e94fa604d33e69c