### PR TITLE
Configure Amplify early and support guest reads

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -24,7 +24,9 @@ const schema = a.schema({
       sections: a.hasMany('Section', 'campaignId'),
     })
     .authorization((allow) => [
+      allow.guest().to(['read']),
       allow.authenticated().to(['read']),
+      allow.group('admin').to(['create', 'update', 'delete']),
     ]),
 
   Section: a
@@ -50,7 +52,9 @@ const schema = a.schema({
       questions: a.hasMany('Question', 'sectionId'),
     })
     .authorization((allow) => [
+      allow.guest().to(['read']),
       allow.authenticated().to(['read']),
+      allow.group('admin').to(['create', 'update', 'delete']),
     ]),
 
   Question: a
@@ -77,7 +81,9 @@ const schema = a.schema({
       responses: a.hasMany('UserResponse', 'questionId'),
     })
     .authorization((allow) => [
+      allow.guest().to(['read']),
       allow.authenticated().to(['read']),
+      allow.group('admin').to(['create', 'update', 'delete']),
     ]),
 
   Title: a
@@ -87,7 +93,9 @@ const schema = a.schema({
       minLevel: a.integer().required(),
     })
     .authorization((allow) => [
+      allow.guest().to(['read']),
       allow.authenticated().to(['read']),
+      allow.group('admin').to(['create', 'update', 'delete']),
     ]),
 
   // ------------------------------------------------------------

--- a/src/amplify.ts
+++ b/src/amplify.ts
@@ -1,0 +1,16 @@
+import { Amplify } from 'aws-amplify';
+import outputs from '../amplify_outputs.json';
+
+declare global {
+  interface Window {
+    __AMPLIFY_CONFIGURED__?: boolean;
+  }
+}
+
+const g = globalThis as unknown as { __AMPLIFY_CONFIGURED__?: boolean };
+if (!g.__AMPLIFY_CONFIGURED__) {
+  Amplify.configure(outputs);
+  g.__AMPLIFY_CONFIGURED__ = true;
+}
+
+export {};

--- a/src/hooks/useCampaignProgress.ts
+++ b/src/hooks/useCampaignProgress.ts
@@ -18,7 +18,7 @@ export function useCampaignProgress(userId?: string | null) {
     setError(null);
     try {
       await ensureSeedData();
-      const sectionRes = await listSections({ selectionSet: ['id', 'campaignId'] });
+      const sectionRes = await listSections({ selectionSet: ['id', 'campaignId'], authMode: 'identityPool' });
       const totals: Record<string, number> = {};
       const sectionToCampaign: Record<string, string> = {};
       for (const s of sectionRes.data ?? []) {
@@ -33,6 +33,7 @@ export function useCampaignProgress(userId?: string | null) {
         const progRes = await listSectionProgress({
           filter: { userId: { eq: userId }, completed: { eq: true } },
           selectionSet: ['sectionId'],
+          authMode: 'userPool',
         });
         for (const row of progRes.data ?? []) {
           const cid = sectionToCampaign[row.sectionId];

--- a/src/hooks/useCampaignQuizData.ts
+++ b/src/hooks/useCampaignQuizData.ts
@@ -52,6 +52,7 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
             'title',
             'isActive',
           ],
+          authMode: 'identityPool',
         });
 
         const rawSections = (sRes.data ?? [])
@@ -120,6 +121,7 @@ export function useCampaignQuizData(activeCampaignId?: string | null) {
             'hint',
             'explanation',
           ],
+          authMode: 'identityPool',
         });
 
         type QuestionRow = {

--- a/src/hooks/useCampaigns.ts
+++ b/src/hooks/useCampaigns.ts
@@ -36,6 +36,7 @@ export function useCampaigns(userId?: string | null) {
       const cRes = await listCampaigns({
         filter: { isActive: { eq: true } },
         selectionSet: ['id', 'title', 'description', 'thumbnailUrl', 'order', 'isActive', 'infoText'],
+        authMode: 'identityPool',
       });
 
       const raw = (cRes.data ?? [])
@@ -48,6 +49,7 @@ export function useCampaigns(userId?: string | null) {
         const pRes = await listCampaignProgress({
           filter: { userId: { eq: userId } },
           selectionSet: ['id', 'campaignId', 'completed'],
+          authMode: 'userPool',
         });
         for (const row of pRes.data ?? []) {
           if (row.completed) completedIds.add(row.campaignId);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,32 +1,16 @@
 // src/main.tsx
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { Amplify } from 'aws-amplify';
-import outputs from '../amplify_outputs.json'; // Amplify Gen 2 outputs (project root)
 import App from './App';
 import { ThemeProvider as AmplifyProvider } from '@aws-amplify/ui-react';
 import customTheme from './theme';
+import './amplify';
 
 // Global styles
 import './styles/theme.css';
 import '@aws-amplify/ui-react/styles.css'; // Amplify UI (Authenticator, etc.)
 import './App.css';
 import './theme.css';
-
-/**
- * Configure Amplify *once* before any Amplify UI components/hooks mount.
- * Calling configure multiple times is generally okay, but during Vite HMR this
- * guard avoids noisy reconfiguration warnings or timing issues.
- */
- (function configureAmplifyOnce() {
-   const g: { __AMPLIFY_CONFIGURED__?: boolean } = globalThis as unknown as {
-     __AMPLIFY_CONFIGURED__?: boolean;
-   };
-   if (!g.__AMPLIFY_CONFIGURED__) {
-     Amplify.configure(outputs);
-     g.__AMPLIFY_CONFIGURED__ = true;
-   }
- })();
 
 const rootEl = document.getElementById('root');
 if (!rootEl) {

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -22,9 +22,10 @@ export async function listCampaigns(
   options: CampaignListOptions = {},
 ) {
   try {
-    return await client.models.Campaign.list(
-      withInfoTextSelection(options),
-    );
+    return await client.models.Campaign.list({
+      authMode: 'identityPool',
+      ...withInfoTextSelection(options),
+    });
   } catch (err) {
     console.error('listCampaigns failed', err);
     throw new ServiceError('Failed to list campaigns', { cause: err });
@@ -35,7 +36,7 @@ export async function createCampaign(
   input: Parameters<typeof client.models.Campaign.create>[0],
 ) {
   try {
-    return await client.models.Campaign.create(input);
+    return await client.models.Campaign.create(input, { authMode: 'userPool' });
   } catch (err) {
     console.error('createCampaign failed', err);
     throw new ServiceError('Failed to create campaign', { cause: err });
@@ -46,7 +47,7 @@ export async function updateCampaign(
   input: Parameters<typeof client.models.Campaign.update>[0],
 ) {
   try {
-    return await client.models.Campaign.update(input);
+    return await client.models.Campaign.update(input, { authMode: 'userPool' });
   } catch (err) {
     console.error('updateCampaign failed', err);
     throw new ServiceError('Failed to update campaign', { cause: err });

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -1,3 +1,4 @@
+import '../amplify';
 import { generateClient } from 'aws-amplify/data';
 import type { Client } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';

--- a/src/services/progressService.ts
+++ b/src/services/progressService.ts
@@ -6,7 +6,7 @@ export async function listCampaignProgress(
   options?: Parameters<typeof client.models.CampaignProgress.list>[0]
 ) {
   try {
-    return await client.models.CampaignProgress.list(options);
+    return await client.models.CampaignProgress.list({ authMode: 'userPool', ...options });
   } catch (err) {
     throw new ServiceError('Failed to list campaign progress', { cause: err });
   }
@@ -16,7 +16,7 @@ export async function createCampaignProgress(
   input: Parameters<typeof client.models.CampaignProgress.create>[0]
 ) {
   try {
-    return await client.models.CampaignProgress.create(input);
+    return await client.models.CampaignProgress.create(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to create campaign progress', { cause: err });
   }
@@ -26,7 +26,7 @@ export async function updateCampaignProgress(
   input: Parameters<typeof client.models.CampaignProgress.update>[0]
 ) {
   try {
-    return await client.models.CampaignProgress.update(input);
+    return await client.models.CampaignProgress.update(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to update campaign progress', { cause: err });
   }
@@ -37,7 +37,7 @@ export async function listSectionProgress(
   options?: Parameters<typeof client.models.SectionProgress.list>[0]
 ) {
   try {
-    return await client.models.SectionProgress.list(options);
+    return await client.models.SectionProgress.list({ authMode: 'userPool', ...options });
   } catch (err) {
     throw new ServiceError('Failed to list section progress', { cause: err });
   }
@@ -47,7 +47,7 @@ export async function createSectionProgress(
   input: Parameters<typeof client.models.SectionProgress.create>[0]
 ) {
   try {
-    return await client.models.SectionProgress.create(input);
+    return await client.models.SectionProgress.create(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to create section progress', { cause: err });
   }
@@ -57,7 +57,7 @@ export async function updateSectionProgress(
   input: Parameters<typeof client.models.SectionProgress.update>[0]
 ) {
   try {
-    return await client.models.SectionProgress.update(input);
+    return await client.models.SectionProgress.update(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to update section progress', { cause: err });
   }
@@ -68,7 +68,7 @@ export async function listUserProgress(
   options?: Parameters<typeof client.models.UserProgress.list>[0]
 ) {
   try {
-    return await client.models.UserProgress.list(options);
+    return await client.models.UserProgress.list({ authMode: 'userPool', ...options });
   } catch (err) {
     throw new ServiceError('Failed to list user progress', { cause: err });
   }
@@ -78,7 +78,7 @@ export async function createUserProgress(
   input: Parameters<typeof client.models.UserProgress.create>[0]
 ) {
   try {
-    return await client.models.UserProgress.create(input);
+    return await client.models.UserProgress.create(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to create user progress', { cause: err });
   }
@@ -88,7 +88,7 @@ export async function updateUserProgress(
   input: Parameters<typeof client.models.UserProgress.update>[0]
 ) {
   try {
-    return await client.models.UserProgress.update(input);
+    return await client.models.UserProgress.update(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to update user progress', { cause: err });
   }
@@ -99,7 +99,7 @@ export async function createUserResponse(
   input: Parameters<typeof client.models.UserResponse.create>[0]
 ) {
   try {
-    return await client.models.UserResponse.create(input);
+    return await client.models.UserResponse.create(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to create user response', { cause: err });
   }
@@ -109,7 +109,7 @@ export async function listUserResponses(
   options?: Parameters<typeof client.models.UserResponse.list>[0]
 ) {
   try {
-    return await client.models.UserResponse.list(options);
+    return await client.models.UserResponse.list({ authMode: 'userPool', ...options });
   } catch (err) {
     throw new ServiceError('Failed to list user responses', { cause: err });
   }

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -5,7 +5,7 @@ export async function listQuestions(
   options?: Parameters<typeof client.models.Question.list>[0]
 ) {
   try {
-    return await client.models.Question.list(options);
+    return await client.models.Question.list({ authMode: 'identityPool', ...options });
   } catch (err) {
     throw new ServiceError('Failed to list questions', { cause: err });
   }
@@ -15,7 +15,7 @@ export async function createQuestion(
   input: Parameters<typeof client.models.Question.create>[0]
 ) {
   try {
-    return await client.models.Question.create(input);
+    return await client.models.Question.create(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to create question', { cause: err });
   }
@@ -25,7 +25,7 @@ export async function updateQuestion(
   input: Parameters<typeof client.models.Question.update>[0]
 ) {
   try {
-    return await client.models.Question.update(input);
+    return await client.models.Question.update(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to update question', { cause: err });
   }
@@ -35,7 +35,7 @@ export async function deleteQuestion(
   input: Parameters<typeof client.models.Question.delete>[0]
 ) {
   try {
-    return await client.models.Question.delete(input);
+    return await client.models.Question.delete(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to delete question', { cause: err });
   }

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -5,7 +5,7 @@ export async function listSections(
   options?: Parameters<typeof client.models.Section.list>[0]
 ) {
   try {
-    return await client.models.Section.list(options);
+    return await client.models.Section.list({ authMode: 'identityPool', ...options });
   } catch (err) {
     console.error('listSections failed', err);
     throw new ServiceError('Failed to list sections', { cause: err });
@@ -16,7 +16,7 @@ export async function createSection(
   input: Parameters<typeof client.models.Section.create>[0]
 ) {
   try {
-    return await client.models.Section.create(input);
+    return await client.models.Section.create(input, { authMode: 'userPool' });
   } catch (err) {
     console.error('createSection failed', err);
     throw new ServiceError('Failed to create section', { cause: err });
@@ -27,7 +27,7 @@ export async function updateSection(
   input: Parameters<typeof client.models.Section.update>[0]
 ) {
   try {
-    return await client.models.Section.update(input);
+    return await client.models.Section.update(input, { authMode: 'userPool' });
   } catch (err) {
     console.error('updateSection failed', err);
     throw new ServiceError('Failed to update section', { cause: err });

--- a/src/services/titleService.ts
+++ b/src/services/titleService.ts
@@ -5,7 +5,7 @@ export async function listTitles(
   options: Parameters<typeof client.models.Title.list>[0] = {}
 ) {
   try {
-    return await client.models.Title.list(options);
+    return await client.models.Title.list({ authMode: 'identityPool', ...options });
   } catch (err) {
     throw new ServiceError('Failed to list titles', { cause: err });
   }

--- a/src/services/userProfileService.ts
+++ b/src/services/userProfileService.ts
@@ -5,7 +5,7 @@ export async function listUserProfiles(
   options?: Parameters<typeof client.models.UserProfile.list>[0]
 ) {
   try {
-    return await client.models.UserProfile.list(options);
+    return await client.models.UserProfile.list({ authMode: 'userPool', ...options });
   } catch (err) {
     throw new ServiceError('Failed to list user profiles', { cause: err });
   }
@@ -15,7 +15,7 @@ export async function createUserProfile(
   input: Parameters<typeof client.models.UserProfile.create>[0]
 ) {
   try {
-    return await client.models.UserProfile.create(input);
+    return await client.models.UserProfile.create(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to create user profile', { cause: err });
   }
@@ -25,7 +25,7 @@ export async function updateUserProfile(
   input: Parameters<typeof client.models.UserProfile.update>[0]
 ) {
   try {
-    return await client.models.UserProfile.update(input);
+    return await client.models.UserProfile.update(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to update user profile', { cause: err });
   }

--- a/src/services/userResponseService.ts
+++ b/src/services/userResponseService.ts
@@ -5,7 +5,7 @@ export async function listUserResponses(
   options?: Parameters<typeof client.models.UserResponse.list>[0]
 ) {
   try {
-    return await client.models.UserResponse.list(options);
+    return await client.models.UserResponse.list({ authMode: 'userPool', ...options });
   } catch (err) {
     throw new ServiceError('Failed to list user responses', { cause: err });
   }
@@ -15,7 +15,7 @@ export async function createUserResponse(
   input: Parameters<typeof client.models.UserResponse.create>[0]
 ) {
   try {
-    return await client.models.UserResponse.create(input);
+    return await client.models.UserResponse.create(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to create user response', { cause: err });
   }
@@ -25,7 +25,7 @@ export async function updateUserResponse(
   input: Parameters<typeof client.models.UserResponse.update>[0]
 ) {
   try {
-    return await client.models.UserResponse.update(input);
+    return await client.models.UserResponse.update(input, { authMode: 'userPool' });
   } catch (err) {
     throw new ServiceError('Failed to update user response', { cause: err });
   }

--- a/src/utils/seedData.ts
+++ b/src/utils/seedData.ts
@@ -4,6 +4,7 @@ import {
 } from '../services/campaignService';
 import { listSections, createSection } from '../services/sectionService';
 import { listQuestions, createQuestion } from '../services/questionService';
+import { getCurrentUser } from 'aws-amplify/auth';
 
 // Deterministically generate campaign/section/question structure so that
 // development environments can auto-populate placeholder content.
@@ -13,6 +14,12 @@ const TOTAL_CAMPAIGNS = 65;
 let seeding: Promise<void> | null = null;
 
 export async function ensureSeedData() {
+  try {
+    await getCurrentUser();
+  } catch {
+    // skip seeding for guests
+    return;
+  }
   if (!seeding) seeding = seedAll();
   return seeding;
 }


### PR DESCRIPTION
## Summary
- centralize Amplify configuration and import before any Data/Auth calls
- allow guest reading of Campaign/Section/Question/Title via identity pool
- guard seeding logic behind authenticated users and default writes to user pool

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689530ffc5ac832e99f5e56338b20858