### PR TITLE
feat: improve header contrast and responsive pills

### DIFF
--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -55,58 +55,6 @@
   flex-wrap: wrap;
 }
 
-.pill {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.45rem 0.75rem;
-  border-radius: 9999px;
-  background-color: var(--color-bg-alt);
-  border: 1px solid var(--color-border-subtle);
-  white-space: nowrap;
-}
-
-.pillPulse {
-  animation: pill-pulse 0.8s ease;
-}
-
-@keyframes pill-pulse {
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.05);
-    box-shadow: 0 0 12px rgba(201, 164, 14, 0.6);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
-.pillIcon {
-  width: var(--pill-icon-size);
-  height: var(--pill-icon-size);
-  object-fit: contain;
-  display: block;
-}
-
-.pillText {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.1;
-}
-
-.pillLabel {
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--pill-label-color, var(--color-text-inverse));
-}
-
-.pillSublabel {
-  font-size: 0.72rem;
-  color: var(--pill-sublabel-color, var(--color-text-muted));
-}
-
 .actions {
   display: flex;
   align-items: center;
@@ -120,12 +68,15 @@
   font-weight: 600;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 390px) {
   .header {
-    padding: 0 1rem;
+    padding: 0 0.75rem;
   }
   .pills {
+    gap: 0.5rem;
     flex-wrap: nowrap;
     overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
   }
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { Button, Text } from '@aws-amplify/ui-react';
 import { useProgress } from '../context/ProgressContext';
 import { xpForLevel, getXPWithinLevel } from '../utils/xp';
 import styles from './Header.module.css';
+import { StatPill } from './StatPill';
 
 export interface HeaderProps {
   signOut?: () => void;
@@ -16,36 +17,6 @@ export interface HeaderProps {
   iconSize?: number;
   /** Controls title font size (rem). Default 1.75. */
   titleSizeRem?: number;
-
-  /** Color for the main label text inside each pill (e.g., "Level 3"). Default #ffffff. */
-  pillLabelColor?: string;
-  /** Color for the sublabel text inside each pill (e.g., "250/1000 XP"). Default #e0e0e0. */
-  pillSubLabelColor?: string;
-}
-
-
-function StatPill({
-  iconSrc,
-  iconAlt,
-  label,
-  sublabel,
-  animate = false,
-}: {
-  iconSrc: string;
-  iconAlt: string;
-  label: string;
-  sublabel?: string;
-  animate?: boolean;
-}) {
-  return (
-    <div className={`${styles.pill} ${animate ? styles.pillPulse : ''}`}>
-      <img src={iconSrc} alt={iconAlt} className={styles.pillIcon} />
-      <div className={styles.pillText}>
-        <Text className={styles.pillLabel}>{label}</Text>
-        {sublabel && <Text className={styles.pillSublabel}>{sublabel}</Text>}
-      </div>
-    </div>
-  );
 }
 
 export const Header = forwardRef<HTMLDivElement, HeaderProps>(
@@ -56,8 +27,6 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(
       logoSize = 95,
       iconSize = 75,
       titleSizeRem = 1.75,
-      pillLabelColor = '#ffffff',
-      pillSubLabelColor = '#e0e0e0',
     },
     ref
   ) => {
@@ -65,7 +34,7 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(
     const { xp, level, streak, completedSections } = useProgress();
     const maxXP = xpForLevel(level);
     const xpWithin = getXPWithinLevel(xp);
-    const xpSub = `${xpWithin}/${maxXP} XP`;
+    const xpValue = `${xpWithin}/${maxXP} XP`;
     const bountiesCompleted = completedSections.length;
 
     const [levelAnim, setLevelAnim] = useState(false);
@@ -127,16 +96,7 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(
       root.style.setProperty('--logo-size', `${logoSize}px`);
       root.style.setProperty('--pill-icon-size', `${iconSize}px`);
       root.style.setProperty('--title-size', `${titleSizeRem}rem`);
-      root.style.setProperty('--pill-label-color', pillLabelColor);
-      root.style.setProperty('--pill-sublabel-color', pillSubLabelColor);
-    }, [
-      height,
-      logoSize,
-      iconSize,
-      titleSizeRem,
-      pillLabelColor,
-      pillSubLabelColor,
-    ]);
+    }, [height, logoSize, iconSize, titleSizeRem]);
 
     return (
       <header ref={ref} className={styles.header}>
@@ -157,23 +117,21 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(
         <div className={styles.pills}>
           <StatPill
             iconSrc="/raccoon.png"
-            iconAlt="Experience"
             label={`Level ${level}`}
-            sublabel={xpSub}
+            value={xpValue}
+            ariaLabel={`Level ${level}, ${xpWithin} of ${maxXP} experience points`}
             animate={levelAnim}
           />
           <StatPill
             iconSrc="/totem.png"
-            iconAlt="Bounties completed"
-            label={`${bountiesCompleted} completed`}
-            sublabel="bounties"
+            label={`${bountiesCompleted} bounties`}
+            ariaLabel={`${bountiesCompleted} completed bounties`}
             animate={bountyAnim}
           />
           <StatPill
             iconSrc="/blaze.png"
-            iconAlt="Daily streak"
-            label={`${streak} day blaze`}
-            sublabel="daily streak"
+            label={`${streak}-day streak`}
+            ariaLabel={`${streak}-day streak`}
             animate={streakAnim}
           />
         </div>

--- a/src/components/StatPill.module.css
+++ b/src/components/StatPill.module.css
@@ -1,0 +1,56 @@
+.pill {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 9999px;
+  background-color: var(--color-surface-dark);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1);
+  color: var(--color-text-inverse);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+  scroll-snap-align: start;
+}
+
+.icon {
+  width: var(--pill-icon-size);
+  height: var(--pill-icon-size);
+  flex-shrink: 0;
+}
+
+.text {
+  max-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pillPulse {
+  animation: pill-pulse 0.8s ease;
+}
+
+@keyframes pill-pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+    box-shadow: 0 0 12px rgba(201, 164, 14, 0.6);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 390px) {
+  .pill {
+    font-size: 0.65rem;
+    padding: 0.25rem 0.5rem;
+    gap: 0.3rem;
+  }
+  .icon {
+    width: 32px;
+    height: 32px;
+  }
+}

--- a/src/components/StatPill.tsx
+++ b/src/components/StatPill.tsx
@@ -1,0 +1,42 @@
+import { Text } from '@aws-amplify/ui-react';
+import styles from './StatPill.module.css';
+
+interface StatPillProps {
+  iconSrc: string;
+  /** Short label to display inside the pill. */
+  label: string;
+  /** Optional value displayed after a dot separator. */
+  value?: string;
+  /** Readable label for screen readers. */
+  ariaLabel: string;
+  /** Trigger scale animation on value change. */
+  animate?: boolean;
+}
+
+export function StatPill({
+  iconSrc,
+  label,
+  value,
+  ariaLabel,
+  animate = false,
+}: StatPillProps) {
+  const text = value ? `${label} • ${value}` : label;
+  return (
+    <div
+      className={`${styles.pill} ${animate ? styles.pillPulse : ''}`}
+      aria-label={ariaLabel}
+    >
+      <img
+        src={iconSrc}
+        alt=""
+        aria-hidden="true"
+        className={styles.icon}
+      />
+      <Text as="span" className={styles.text} title={text}>
+        {text}
+      </Text>
+    </div>
+  );
+}
+
+export default StatPill;


### PR DESCRIPTION
## Summary
- replace inline stat pill markup with reusable `StatPill` component
- simplify pill text and add screen reader labels
- tweak header and pill styling for high contrast and mobile scroll behavior

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689533e488bc832e849ae4cb7b7a77c3