### PR TITLE
feat: seed campaign thumbnails in dev

### DIFF
--- a/src/hooks/useCampaignThumbnail.ts
+++ b/src/hooks/useCampaignThumbnail.ts
@@ -1,6 +1,7 @@
 // src/hooks/useCampaignThumbnail.ts
 import { useEffect, useState } from 'react';
 import { getUrl } from 'aws-amplify/storage';
+import { fetchRandomSeedThumbnail } from '../utils/seedThumbnails';
 
 // Simple in-memory cache for resolved URLs
 const urlCache = new Map<string, string>();
@@ -11,53 +12,75 @@ type Options = {
 };
 
 export function useCampaignThumbnail({ key, fallbackUrl }: Options) {
+  // When running locally with no key/url provided, we can seed thumbnails
+  // from the `seed-thumbnails` directory for testing.
+  const shouldSeed = !key && !fallbackUrl && import.meta.env.DEV;
+
   const [url, setUrl] = useState<string | null>(fallbackUrl ?? null);
-  const [loading, setLoading] = useState<boolean>(!!key);
+  const [loading, setLoading] = useState<boolean>(!!key || shouldSeed);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
     async function resolve() {
-      if (!key) {
-        setLoading(false);
-        setUrl(fallbackUrl ?? null);
+      if (key) {
+        // Serve from cache if available
+        const cached = urlCache.get(key);
+        if (cached) {
+          setUrl(cached);
+          setLoading(false);
+          return;
+        }
+
+        setLoading(true);
+        setError(null);
+        try {
+          // public level since our storage rule exposes public/*
+          const result = await getUrl({ path: `public/${key}` });
+          if (!cancelled) {
+            const resolved = result.url.toString();
+            urlCache.set(key, resolved);
+            setUrl(resolved);
+          }
+        } catch (e) {
+          if (!cancelled) {
+            setError(e as Error);
+            setUrl(fallbackUrl ?? null);
+          }
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
         return;
       }
 
-      // Serve from cache if available
-      const cached = urlCache.get(key);
-      if (cached) {
-        setUrl(cached);
-        setLoading(false);
+      // No key provided. If we are in development mode, attempt to
+      // fetch a random seed thumbnail from S3.
+      if (shouldSeed) {
+        try {
+          const seededUrl = await fetchRandomSeedThumbnail();
+          if (!cancelled) setUrl(seededUrl);
+        } catch (e) {
+          if (!cancelled) {
+            setError(e as Error);
+            setUrl(null);
+          }
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
         return;
       }
 
-      setLoading(true);
-      setError(null);
-      try {
-        // public level since our storage rule exposes public/*
-        const result = await getUrl({ path: `public/${key}` });
-        if (!cancelled) {
-          const resolved = result.url.toString();
-          urlCache.set(key, resolved);
-          setUrl(resolved);
-        }
-      } catch (e) {
-        if (!cancelled) {
-          setError(e as Error);
-          setUrl(fallbackUrl ?? null);
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
+      // Fall back to any absolute URL provided in the campaign data.
+      setLoading(false);
+      setUrl(fallbackUrl ?? null);
     }
 
     resolve();
     return () => {
       cancelled = true;
     };
-  }, [key, fallbackUrl]);
+  }, [key, fallbackUrl, shouldSeed]);
 
   return { url, loading, error };
 }

--- a/src/utils/seedThumbnails.ts
+++ b/src/utils/seedThumbnails.ts
@@ -1,0 +1,23 @@
+import { list, getUrl } from 'aws-amplify/storage';
+
+// Cache the list of seed thumbnail paths in memory so we only
+// hit S3 once per session.
+let cachedPaths: string[] | null = null;
+
+/**
+ * Retrieve a random thumbnail URL from the `seed-thumbnails/` directory.
+ * The directory lives at the root of the public bucket and contains PNG files.
+ *
+ * Returns `null` if no thumbnails are found.
+ */
+export async function fetchRandomSeedThumbnail(): Promise<string | null> {
+  if (!cachedPaths) {
+    const res = await list({ path: 'public/seed-thumbnails/' });
+    cachedPaths =
+      res.items?.filter((item) => item.path.toLowerCase().endsWith('.png')).map((i) => i.path) ?? [];
+  }
+  if (!cachedPaths.length) return null;
+  const randomPath = cachedPaths[Math.floor(Math.random() * cachedPaths.length)];
+  const urlRes = await getUrl({ path: randomPath });
+  return urlRes.url.toString();
+}


### PR DESCRIPTION
## Summary
- fetch random thumbnail from `seed-thumbnails/` in S3 for development
- use seeded thumbnails when campaigns lack custom images

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68953e0c0adc832ea3cc0291c2b7de4a