### PR TITLE
feat: enable public campaign content

### DIFF
--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -11,9 +11,16 @@ interface Props {
   displayName?: string;
   onProgress?: (p: Progress) => void;
   onRequireAuth?: () => void;
+  /** When true, data is loaded using unauthenticated (public) access. */
+  publicMode?: boolean;
 }
 
-export default function CampaignCanvas({ displayName, onProgress, onRequireAuth }: Props) {
+export default function CampaignCanvas({
+  displayName,
+  onProgress,
+  onRequireAuth,
+  publicMode = false,
+}: Props) {
   const { activeCampaignId } = useActiveCampaign();
 
   const {
@@ -24,7 +31,7 @@ export default function CampaignCanvas({ displayName, onProgress, onRequireAuth 
     sectionTextByNumber,
     sectionTitleByNumber,
     sectionIdByNumber,
-  } = useCampaignQuizData(activeCampaignId);
+  } = useCampaignQuizData(activeCampaignId, publicMode);
 
   useEffect(() => {
     if (progress && onProgress) {

--- a/src/pages/PublicShell.tsx
+++ b/src/pages/PublicShell.tsx
@@ -31,7 +31,7 @@ export default function PublicShell({ onRequireAuth }: PublicShellProps) {
           </div>
           <div className={styles.canvasArea}>
             <Suspense fallback={<Skeleton height="200px" />}>
-              <CampaignCanvas onRequireAuth={onRequireAuth} />
+              <CampaignCanvas onRequireAuth={onRequireAuth} publicMode />
             </Suspense>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- allow PublicShell to load campaigns without signing in
- support public mode in CampaignCanvas and useCampaignQuizData with fallback seed data
- provide fallback campaign list for unauthenticated users

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689540e9ae8c832e8c2e56bd6ea57383