### PR TITLE
feat: load seed campaigns without auth in public shell

### DIFF
--- a/src/hooks/useCampaignQuizData.ts
+++ b/src/hooks/useCampaignQuizData.ts
@@ -91,7 +91,7 @@ export function useCampaignQuizData(
       };
 
       try {
-        if (!publicMode) await ensureSeedData();
+        await ensureSeedData(); // TODO: re-enable auth gating
 
         const sRes = await listSections({
           filter: { campaignId: { eq: campaignId } },
@@ -104,7 +104,7 @@ export function useCampaignQuizData(
             'title',
             'isActive',
           ],
-          authMode: 'identityPool',
+          authMode: publicMode ? 'apiKey' : 'identityPool', // TODO: re-enable auth gating
         });
 
         const rawSections = (sRes.data ?? [])
@@ -178,7 +178,7 @@ export function useCampaignQuizData(
             'hint',
             'explanation',
           ],
-          authMode: 'identityPool',
+          authMode: publicMode ? 'apiKey' : 'identityPool', // TODO: re-enable auth gating
         });
 
         type QuestionRow = {

--- a/src/hooks/useCampaigns.ts
+++ b/src/hooks/useCampaigns.ts
@@ -48,7 +48,7 @@ export function useCampaigns(userId?: string | null) {
       const cRes = await listCampaigns({
         filter: { isActive: { eq: true } },
         selectionSet: ['id', 'title', 'description', 'thumbnailUrl', 'order', 'isActive', 'infoText'],
-        authMode: 'identityPool',
+        authMode: userId ? 'identityPool' : 'apiKey', // TODO: re-enable auth gating
       });
 
       let raw: CampaignRow[] = (cRes.data ?? [])

--- a/src/pages/PublicShell.tsx
+++ b/src/pages/PublicShell.tsx
@@ -13,7 +13,8 @@ interface PublicShellProps {
   onRequireAuth: () => void;
 }
 
-export default function PublicShell({ onRequireAuth }: PublicShellProps) {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function PublicShell(_props: PublicShellProps) {
   return (
     <ActiveCampaignProvider>
       <GuestProgressProvider>
@@ -31,7 +32,8 @@ export default function PublicShell({ onRequireAuth }: PublicShellProps) {
           </div>
           <div className={styles.canvasArea}>
             <Suspense fallback={<Skeleton height="200px" />}>
-              <CampaignCanvas onRequireAuth={onRequireAuth} publicMode />
+              {/* TODO: re-enable auth gating */}
+              <CampaignCanvas publicMode />
             </Suspense>
           </div>
         </div>

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -23,7 +23,7 @@ export async function listCampaigns(
 ) {
   try {
     return await client.models.Campaign.list({
-      authMode: 'identityPool',
+      authMode: 'apiKey', // TODO: re-enable auth gating
       ...withInfoTextSelection(options),
     });
   } catch (err) {

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -5,7 +5,10 @@ export async function listQuestions(
   options?: Parameters<typeof client.models.Question.list>[0]
 ) {
   try {
-    return await client.models.Question.list({ authMode: 'identityPool', ...options });
+    return await client.models.Question.list({
+      authMode: 'apiKey', // TODO: re-enable auth gating
+      ...options,
+    });
   } catch (err) {
     throw new ServiceError('Failed to list questions', { cause: err });
   }

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -5,7 +5,10 @@ export async function listSections(
   options?: Parameters<typeof client.models.Section.list>[0]
 ) {
   try {
-    return await client.models.Section.list({ authMode: 'identityPool', ...options });
+    return await client.models.Section.list({
+      authMode: 'apiKey', // TODO: re-enable auth gating
+      ...options,
+    });
   } catch (err) {
     console.error('listSections failed', err);
     throw new ServiceError('Failed to list sections', { cause: err });


### PR DESCRIPTION
## Summary
- allow campaign/services to fetch via API key so public visitors can read seed data
- load campaign quiz data without auth and fall back to seed content
- disable auth prompt in `PublicShell` for temporary public access

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689548da799c832eb6e1ba2380299284