### PR TITLE
fix: adjust top spacing and pill text styling

### DIFF
--- a/src/components/StatPill.module.css
+++ b/src/components/StatPill.module.css
@@ -18,6 +18,11 @@
   flex-shrink: 0;
 }
 
+.text {
+  color: #ffffff;
+  font-weight: 800;
+}
+
 .textWrapper {
   display: flex;
   flex-direction: column;

--- a/src/pages/AuthenticatedShell.css
+++ b/src/pages/AuthenticatedShell.css
@@ -8,6 +8,7 @@
   grid-auto-rows: auto;
   min-height: 100vh;
   gap: 24px;
+  padding-top: calc(var(--header-height) + 24px);
 }
 
 .auth-header {

--- a/src/pages/PublicShell.module.css
+++ b/src/pages/PublicShell.module.css
@@ -8,6 +8,7 @@
   grid-auto-rows: auto;
   min-height: 100vh;
   gap: var(--space-lg, 24px);
+  padding-top: calc(var(--header-height) + var(--space-lg, 24px));
 }
 
 .headerArea {


### PR DESCRIPTION
## Summary
- add top padding to shell layouts so content sits below fixed header
- style pill text with bold white font for better readability

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689554d31330832eb40bb5b12e82c02a