### PR TITLE
fix: ensure proper top padding for header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -35,7 +35,7 @@ body {
 }
 
 main {
-  padding-top: calc(var(--header-height) + 60px);
+  padding-top: calc(var(--header-height) + var(--space-lg, 24px));
 }
 
 @media (max-width: 1024px) {

--- a/src/components/DisplayNamePrompt.module.css
+++ b/src/components/DisplayNamePrompt.module.css
@@ -1,3 +1,9 @@
+
+/* Ensure the prompt clears the fixed header */
+.container {
+  margin-top: calc(var(--header-height) + var(--space-lg, 24px));
+}
+
 .form {
   display: flex;
   gap: var(--space-xs, 8px);

--- a/src/components/DisplayNamePrompt.tsx
+++ b/src/components/DisplayNamePrompt.tsx
@@ -43,22 +43,24 @@ export default function DisplayNamePrompt() {
   };
 
   return (
-    <Card variation="elevated" marginBottom="large" padding="large">
-      <Heading level={4} marginBottom="small">
-        Choose a display name
-      </Heading>
-      <form onSubmit={handleSubmit} className={styles.form}>
-        <TextField
-          label="Display name"
-          value={name}
-          onChange={onChange}
-          placeholder="Display name"
-          maxLength={20}
-        />
-        <Button type="submit">Save</Button>
-      </form>
-      {error && <div className={styles.error}>{error}</div>}
-    </Card>
+    <div className={styles.container}>
+      <Card variation="elevated" marginBottom="large" padding="large">
+        <Heading level={4} marginBottom="small">
+          Choose a display name
+        </Heading>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <TextField
+            label="Display name"
+            value={name}
+            onChange={onChange}
+            placeholder="Display name"
+            maxLength={20}
+          />
+          <Button type="submit">Save</Button>
+        </form>
+        {error && <div className={styles.error}>{error}</div>}
+      </Card>
+    </div>
   );
 }
 

--- a/src/pages/AuthenticatedShell.css
+++ b/src/pages/AuthenticatedShell.css
@@ -8,7 +8,7 @@
   grid-auto-rows: auto;
   min-height: 100vh;
   gap: 24px;
-  padding-top: calc(var(--header-height) + 24px);
+  padding-top: calc(var(--header-height) + var(--space-lg, 24px));
 }
 
 .auth-header {


### PR DESCRIPTION
## Summary
- add top-margin container to DisplayNamePrompt so form clears fixed header
- standardize header offset using space variable

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689562507734832e926654492a3bd92a