### PR TITLE
Allow campaign access without auth

### DIFF
--- a/src/pages/AuthenticatedShell.tsx
+++ b/src/pages/AuthenticatedShell.tsx
@@ -48,13 +48,13 @@ export default function AuthenticatedShell() {
 
             <div className="auth-gallery">
               <Suspense fallback={<Skeleton height="180px" />}>
-                <CampaignGallery />
+                <CampaignGallery publicMode />
               </Suspense>
             </div>
 
             <div className="auth-canvas">
               <Suspense fallback={<Skeleton height="200px" />}>
-                <CampaignCanvas />
+                <CampaignCanvas publicMode />
               </Suspense>
             </div>
 


### PR DESCRIPTION
## Summary
- enable CampaignGallery and CampaignCanvas to run in public mode
- let useCampaigns pull data via API key and local progress when unauthenticated
- load campaign content without authentication gating

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68956e4d1e6c832e90ae228e0e81cae2