### PR TITLE
feat: remove auth gating and centralize progression

### DIFF
--- a/src/components/CampaignCanvas.tsx
+++ b/src/components/CampaignCanvas.tsx
@@ -6,6 +6,8 @@ import { useCampaignQuizData } from '../hooks/useCampaignQuizData';
 import { useActiveCampaign } from '../context/ActiveCampaignContext';
 import type { Progress } from '../types/ProgressTypes';
 import { createEmptyProgress } from '../types/ProgressTypes';
+import { canUnlock } from '../domain/progression';
+import { AUTH_DISABLED } from '../config/runtime';
 
 interface Props {
   displayName?: string;
@@ -85,6 +87,7 @@ export default function CampaignCanvas({
   const promptedAuth = useRef(false);
   useEffect(() => {
     if (
+      AUTH_DISABLED ||
       promptedAuth.current ||
       !onRequireAuth ||
       activeCampaignId !== 'campaign-1'
@@ -120,12 +123,13 @@ export default function CampaignCanvas({
 
   return (
     <>
-      {orderedSectionNumbers.map((sectionNum, idx) => {
+      {orderedSectionNumbers.map((sectionNum) => {
         const questionsInSection = groupedBySection.get(sectionNum) ?? [];
-        const isLocked =
-          !safeProgress.completedSections.includes(sectionNum) &&
-          sectionNum !== orderedSectionNumbers[0] &&
-          !safeProgress.completedSections.includes(orderedSectionNumbers[idx - 1]);
+        const isLocked = !canUnlock(
+          sectionNum,
+          safeProgress.completedSections,
+          orderedSectionNumbers,
+        );
         const answeredCount = questionsInSection.filter((q) =>
           safeProgress.answeredQuestions.includes(q.id)
         ).length;

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -1,0 +1,3 @@
+export const AUTH_DISABLED = true; // set to false to re-enable auth gating
+export type ProgressionStorageMode = 'remote' | 'local';
+export const PROGRESSION_STORAGE: ProgressionStorageMode = 'local';

--- a/src/domain/progressStore.ts
+++ b/src/domain/progressStore.ts
@@ -1,0 +1,38 @@
+import type { ProgressState } from './progression';
+
+const STORAGE_KEY = 'guestProgress';
+
+export function getProgress(): ProgressState {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw) {
+    try {
+      const data = JSON.parse(raw) as ProgressState;
+      return {
+        xp: data.xp ?? 0,
+        streak: data.streak ?? 0,
+        completedSections: Array.isArray(data.completedSections) ? data.completedSections : [],
+        completedCampaigns: Array.isArray(data.completedCampaigns) ? data.completedCampaigns : [],
+        answeredQuestions: Array.isArray(data.answeredQuestions) ? data.answeredQuestions : [],
+        lastBlazeAt: data.lastBlazeAt ?? null,
+      };
+    } catch {
+      /* ignore */
+    }
+  }
+  return {
+    xp: 0,
+    streak: 0,
+    completedSections: [],
+    completedCampaigns: [],
+    answeredQuestions: [],
+    lastBlazeAt: null,
+  };
+}
+
+export function saveProgress(state: ProgressState) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/domain/progression.ts
+++ b/src/domain/progression.ts
@@ -1,0 +1,108 @@
+import { getLevelFromXP } from '../utils/xp';
+
+export interface ProgressState {
+  xp: number;
+  streak: number;
+  completedSections: number[];
+  completedCampaigns: string[];
+  answeredQuestions: string[];
+  lastBlazeAt: string | null;
+}
+
+export const XP_FOR_SECTION = 40;
+export const XP_FOR_CAMPAIGN = 150;
+
+function startOfDay(d: Date) {
+  const t = new Date(d);
+  t.setHours(0, 0, 0, 0);
+  return t;
+}
+
+export function awardXPIfEligible(
+  state: ProgressState,
+  amount: number,
+  now = new Date(),
+): ProgressState {
+  let { streak, lastBlazeAt, xp } = state;
+  const todayStart = startOfDay(now);
+  const last = lastBlazeAt ? new Date(lastBlazeAt) : null;
+  if (!last) {
+    streak = 1;
+  } else {
+    const lastStart = startOfDay(last);
+    const diff = Math.floor((todayStart.getTime() - lastStart.getTime()) / 86400000);
+    if (diff === 1) streak = Math.max(1, streak) + 1;
+    else if (diff > 1) streak = 1;
+    else streak = Math.max(1, streak);
+  }
+  lastBlazeAt = now.toISOString();
+  xp += amount;
+  return { ...state, xp, streak, lastBlazeAt };
+}
+
+export function computeLevelFromXP(xp: number): number {
+  return getLevelFromXP(xp);
+}
+
+export function markQuestionAnswered(
+  state: ProgressState,
+  questionId: string,
+  isCorrect: boolean,
+  xp = 0,
+): { state: ProgressState; awardedXP: number } {
+  if (!isCorrect || state.answeredQuestions.includes(questionId)) {
+    return { state, awardedXP: 0 };
+  }
+  const newState = awardXPIfEligible(state, xp);
+  return {
+    state: {
+      ...newState,
+      answeredQuestions: [...newState.answeredQuestions, questionId],
+    },
+    awardedXP: xp,
+  };
+}
+
+export function computeSectionCompletion(
+  state: ProgressState,
+  sectionNumber: number,
+): { state: ProgressState; awardedXP: number } {
+  if (state.completedSections.includes(sectionNumber)) {
+    return { state, awardedXP: 0 };
+  }
+  const newState = awardXPIfEligible(state, XP_FOR_SECTION);
+  return {
+    state: {
+      ...newState,
+      completedSections: [...newState.completedSections, sectionNumber],
+    },
+    awardedXP: XP_FOR_SECTION,
+  };
+}
+
+export function computeCampaignCompletion(
+  state: ProgressState,
+  campaignId: string,
+): { state: ProgressState; awardedXP: number } {
+  if (state.completedCampaigns.includes(campaignId)) {
+    return { state, awardedXP: 0 };
+  }
+  const newState = awardXPIfEligible(state, XP_FOR_CAMPAIGN);
+  return {
+    state: {
+      ...newState,
+      completedCampaigns: [...newState.completedCampaigns, campaignId],
+    },
+    awardedXP: XP_FOR_CAMPAIGN,
+  };
+}
+
+export function canUnlock<T>(id: T, completed: Set<T> | T[], ordered: T[]): boolean {
+  const completedSet = completed instanceof Set ? completed : new Set(completed);
+  const idx = ordered.indexOf(id);
+  if (idx <= 0) return true;
+  for (let i = 0; i < idx; i++) {
+    if (!completedSet.has(ordered[i])) return false;
+  }
+  return true;
+}

--- a/src/pages/AuthenticatedShell.tsx
+++ b/src/pages/AuthenticatedShell.tsx
@@ -15,6 +15,7 @@ import { ActiveCampaignProvider } from '../context/ActiveCampaignContext';
 import { UserProfileProvider } from '../context/UserProfileContext';
 import DisplayNamePrompt from '../components/DisplayNamePrompt';
 import './AuthenticatedShell.css';
+import { AUTH_DISABLED } from '../config/runtime';
 
 export default function AuthenticatedShell() {
   const [userId] = useState(() => {
@@ -48,13 +49,13 @@ export default function AuthenticatedShell() {
 
             <div className="auth-gallery">
               <Suspense fallback={<Skeleton height="180px" />}>
-                <CampaignGallery publicMode />
+                <CampaignGallery publicMode={AUTH_DISABLED} />
               </Suspense>
             </div>
 
             <div className="auth-canvas">
               <Suspense fallback={<Skeleton height="200px" />}>
-                <CampaignCanvas publicMode />
+                <CampaignCanvas publicMode={AUTH_DISABLED} />
               </Suspense>
             </div>
 


### PR DESCRIPTION
## Summary
- allow anonymous usage behind `AUTH_DISABLED` flag
- centralize campaign progression logic in domain module
- persist progress via small storage interface

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689575016b9c832ebcde13e4d25c5134